### PR TITLE
Interactive components

### DIFF
--- a/kite-service/cmd/server.go
+++ b/kite-service/cmd/server.go
@@ -67,6 +67,7 @@ func serverStartCMD(c *cli.Context) error {
 		pg,
 		pg,
 		pg,
+		pg,
 		&http.Client{}, // TODO: think about proxying http requests
 	)
 	engine.Run(ctx)

--- a/kite-service/internal/api/handler/message/instances.go
+++ b/kite-service/internal/api/handler/message/instances.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (h *MessageHandler) HandleMessageInstanceList(c *handler.Context) (*wire.MessageInstanceListResponse, error) {
-	instances, err := h.messageInstanceStore.MessageInstancesByMessage(c.Context(), c.Message.ID)
+	instances, err := h.messageInstanceStore.MessageInstancesByMessage(c.Context(), c.Message.ID, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get message instances: %w", err)
 	}

--- a/kite-service/internal/api/handler/middleware.go
+++ b/kite-service/internal/api/handler/middleware.go
@@ -18,6 +18,10 @@ func TypedWithBody[REQ any, RESP any](next func(c *Context, r REQ) (*RESP, error
 			return err
 		}
 
+		if sanitizable, ok := interface{}(&v).(BodySanitize); ok {
+			sanitizable.Sanitize()
+		}
+
 		if validatable, ok := interface{}(&v).(BodyValidate); ok {
 			if err := validatable.Validate(); err != nil {
 				return err
@@ -52,6 +56,10 @@ func Typed[RESP any](next func(c *Context) (*RESP, error)) HandlerFunc {
 
 type BodyValidate interface {
 	Validate() error
+}
+
+type BodySanitize interface {
+	Sanitize()
 }
 
 func RateLimitByUser(tokens uint64, interval time.Duration) MiddlewareFunc {

--- a/kite-service/internal/api/wire/message.go
+++ b/kite-service/internal/api/wire/message.go
@@ -34,6 +34,21 @@ type MessageCreateRequest struct {
 	FlowSources map[string]flow.FlowData `json:"flow_sources"`
 }
 
+func (req *MessageCreateRequest) Sanitize() {
+	// Remove unused flow sources
+	newFlowSources := make(map[string]flow.FlowData, len(req.FlowSources))
+	for _, row := range req.Data.Components {
+		for _, comp := range row.Components {
+			flow, ok := req.FlowSources[comp.FlowSourceID]
+			if ok {
+				newFlowSources[comp.FlowSourceID] = flow
+			}
+		}
+	}
+
+	req.FlowSources = newFlowSources
+}
+
 func (req MessageCreateRequest) Validate() error {
 	return validation.ValidateStruct(&req,
 		validation.Field(&req.Name, validation.Required, validation.Length(1, 100)),
@@ -48,6 +63,21 @@ type MessageUpdateRequest struct {
 	Description null.String              `json:"description"`
 	Data        message.MessageData      `json:"data"`
 	FlowSources map[string]flow.FlowData `json:"flow_sources"`
+}
+
+func (req *MessageUpdateRequest) Sanitize() {
+	// Remove unused flow sources
+	newFlowSources := make(map[string]flow.FlowData, len(req.FlowSources))
+	for _, row := range req.Data.Components {
+		for _, comp := range row.Components {
+			flow, ok := req.FlowSources[comp.FlowSourceID]
+			if ok {
+				newFlowSources[comp.FlowSourceID] = flow
+			}
+		}
+	}
+
+	req.FlowSources = newFlowSources
 }
 
 func (req MessageUpdateRequest) Validate() error {

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -31,7 +31,8 @@ type App struct {
 	hasUndeployedChanges bool
 
 	commands map[string]*Command
-	events   map[string]interface{}
+	// TODO: messages LRUCache<*MessageInstance>
+	events map[string]interface{}
 }
 
 func NewApp(
@@ -129,7 +130,6 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 			}
 		case *discord.ButtonInteraction:
 			messageID := e.Message.ID.String()
-			// TODO: cache with LRU?
 			messageInstnace, err := a.messageInstanceStore.MessageInstanceByDiscordMessageID(context.TODO(), messageID)
 			if err != nil {
 				if errors.Is(err, store.ErrNotFound) {

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -141,7 +141,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 				return
 			}
 
-			instnace, err := NewMessageInstance(
+			instance, err := NewMessageInstance(
 				a.config,
 				messageInstnace,
 				a.appStore,
@@ -155,7 +155,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 				return
 			}
 
-			go instnace.HandleEvent(appID, session, event)
+			go instance.HandleEvent(appID, session, event)
 		}
 	}
 }

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -69,6 +69,7 @@ func (a *App) AddCommand(cmd *model.Command) {
 		a.appStore,
 		a.logStore,
 		a.messageStore,
+		a.messageInstanceStore,
 		a.httpClient,
 	)
 	if err != nil {
@@ -146,6 +147,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 				a.appStore,
 				a.logStore,
 				a.messageStore,
+				a.messageInstanceStore,
 				a.httpClient,
 			)
 			if err != nil {

--- a/kite-service/internal/core/engine/command.go
+++ b/kite-service/internal/core/engine/command.go
@@ -20,13 +20,14 @@ import (
 )
 
 type Command struct {
-	config       EngineConfig
-	cmd          *model.Command
-	flow         *flow.CompiledFlowNode
-	appStore     store.AppStore
-	logStore     store.LogStore
-	messageStore store.MessageStore
-	httpClient   *http.Client
+	config               EngineConfig
+	cmd                  *model.Command
+	flow                 *flow.CompiledFlowNode
+	appStore             store.AppStore
+	logStore             store.LogStore
+	messageStore         store.MessageStore
+	messageInstanceStore store.MessageInstanceStore
+	httpClient           *http.Client
 }
 
 func NewCommand(
@@ -35,6 +36,7 @@ func NewCommand(
 	appStore store.AppStore,
 	logStore store.LogStore,
 	messageStore store.MessageStore,
+	messageInstanceStore store.MessageInstanceStore,
 	httpClient *http.Client,
 ) (*Command, error) {
 	flow, err := flow.CompileCommand(cmd.FlowSource)
@@ -43,13 +45,14 @@ func NewCommand(
 	}
 
 	return &Command{
-		config:       config,
-		cmd:          cmd,
-		flow:         flow,
-		appStore:     appStore,
-		logStore:     logStore,
-		messageStore: messageStore,
-		httpClient:   httpClient,
+		config:               config,
+		cmd:                  cmd,
+		flow:                 flow,
+		appStore:             appStore,
+		logStore:             logStore,
+		messageStore:         messageStore,
+		messageInstanceStore: messageInstanceStore,
+		httpClient:           httpClient,
 	}, nil
 }
 
@@ -63,7 +66,7 @@ func (c *Command) HandleEvent(appID string, session *state.State, event gateway.
 		Discord:         NewDiscordProvider(appID, c.appStore, session),
 		Log:             NewLogProvider(appID, c.logStore),
 		HTTP:            NewHTTPProvider(c.httpClient),
-		MessageTemplate: NewMessageTemplateProvider(c.messageStore),
+		MessageTemplate: NewMessageTemplateProvider(c.messageStore, c.messageInstanceStore),
 		// TODO: Variable provider
 	}
 

--- a/kite-service/internal/core/engine/engine.go
+++ b/kite-service/internal/core/engine/engine.go
@@ -16,12 +16,13 @@ import (
 type Engine struct {
 	sync.RWMutex
 
-	config       EngineConfig
-	appStore     store.AppStore
-	logStore     store.LogStore
-	messageStore store.MessageStore
-	commandStore store.CommandStore
-	httpClient   *http.Client
+	config               EngineConfig
+	appStore             store.AppStore
+	logStore             store.LogStore
+	messageStore         store.MessageStore
+	messageInstanceStore store.MessageInstanceStore
+	commandStore         store.CommandStore
+	httpClient           *http.Client
 
 	lastUpdate time.Time
 	apps       map[string]*App
@@ -32,17 +33,19 @@ func NewEngine(
 	appStore store.AppStore,
 	logStore store.LogStore,
 	messageStore store.MessageStore,
+	messageInstanceStore store.MessageInstanceStore,
 	commandStore store.CommandStore,
 	httpClient *http.Client,
 ) *Engine {
 	return &Engine{
-		config:       config,
-		appStore:     appStore,
-		logStore:     logStore,
-		messageStore: messageStore,
-		httpClient:   httpClient,
-		commandStore: commandStore,
-		apps:         make(map[string]*App),
+		config:               config,
+		appStore:             appStore,
+		logStore:             logStore,
+		messageStore:         messageStore,
+		messageInstanceStore: messageInstanceStore,
+		httpClient:           httpClient,
+		commandStore:         commandStore,
+		apps:                 make(map[string]*App),
 	}
 }
 
@@ -96,6 +99,7 @@ func (m *Engine) populateCommands(ctx context.Context) error {
 				m.appStore,
 				m.logStore,
 				m.messageStore,
+				m.messageInstanceStore,
 				m.commandStore,
 				m.httpClient,
 			)

--- a/kite-service/internal/core/engine/message.go
+++ b/kite-service/internal/core/engine/message.go
@@ -1,0 +1,120 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/diamondburned/arikawa/v3/discord"
+	"github.com/diamondburned/arikawa/v3/gateway"
+	"github.com/diamondburned/arikawa/v3/state"
+	"github.com/kitecloud/kite/kite-service/internal/model"
+	"github.com/kitecloud/kite/kite-service/internal/store"
+	"github.com/kitecloud/kite/kite-service/pkg/flow"
+	"github.com/kitecloud/kite/kite-service/pkg/placeholder"
+)
+
+type MessageInstance struct {
+	config       EngineConfig
+	msg          *model.MessageInstance
+	flows        map[string]*flow.CompiledFlowNode
+	appStore     store.AppStore
+	logStore     store.LogStore
+	messageStore store.MessageStore
+	httpClient   *http.Client
+}
+
+func NewMessageInstance(
+	config EngineConfig,
+	msg *model.MessageInstance,
+	appStore store.AppStore,
+	logStore store.LogStore,
+	messageStore store.MessageStore,
+	httpClient *http.Client,
+) (*MessageInstance, error) {
+	flows := make(map[string]*flow.CompiledFlowNode, len(msg.FlowSources))
+
+	for id, flowSource := range msg.FlowSources {
+		flow, err := flow.CompileComponentButton(flowSource)
+		if err != nil {
+			slog.With("error", err).Error("Failed to compile component button flow")
+			continue
+		}
+
+		flows[id] = flow
+	}
+
+	return &MessageInstance{
+		config:       config,
+		msg:          msg,
+		flows:        flows,
+		appStore:     appStore,
+		logStore:     logStore,
+		messageStore: messageStore,
+		httpClient:   httpClient,
+	}, nil
+}
+
+func (c *MessageInstance) HandleEvent(appID string, session *state.State, event gateway.Event) {
+	i, ok := event.(*gateway.InteractionCreateEvent)
+	if !ok {
+		return
+	}
+
+	d, ok := i.InteractionEvent.Data.(*discord.ButtonInteraction)
+	if !ok {
+		return
+	}
+
+	targetFlow, ok := c.flows[string(d.CustomID)]
+	if !ok {
+		return
+	}
+
+	providers := flow.FlowProviders{
+		Discord:         NewDiscordProvider(appID, c.appStore, session),
+		Log:             NewLogProvider(appID, c.logStore),
+		HTTP:            NewHTTPProvider(c.httpClient),
+		MessageTemplate: NewMessageTemplateProvider(c.messageStore),
+		// TODO: Variable provider
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fCtx := flow.NewContext(ctx,
+		&InteractionData{
+			interaction: &i.InteractionEvent,
+		},
+		providers,
+		flow.FlowContextLimits{
+			MaxStackDepth: c.config.MaxStackDepth,
+			MaxOperations: c.config.MaxOperations,
+			MaxActions:    c.config.MaxActions,
+		},
+		placeholder.NewEngine(),
+	)
+
+	if err := targetFlow.Execute(fCtx); err != nil {
+		go c.createLogEntry(model.LogLevelError, fmt.Sprintf("Failed to execute command flow: %v", err))
+		slog.With("error", err).Error("Failed to execute command flow")
+	}
+}
+
+func (c *MessageInstance) createLogEntry(level model.LogLevel, message string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Create log entry which will be displayed in the dashboard
+	err := c.logStore.CreateLogEntry(ctx, model.LogEntry{
+		AppID:     "TODO", // TODO: appID
+		Level:     level,
+		Message:   message,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		slog.With("error", err).With("app_id", "TODO").Error("Failed to create log entry from engine command")
+	}
+}

--- a/kite-service/internal/core/engine/message.go
+++ b/kite-service/internal/core/engine/message.go
@@ -17,13 +17,14 @@ import (
 )
 
 type MessageInstance struct {
-	config       EngineConfig
-	msg          *model.MessageInstance
-	flows        map[string]*flow.CompiledFlowNode
-	appStore     store.AppStore
-	logStore     store.LogStore
-	messageStore store.MessageStore
-	httpClient   *http.Client
+	config               EngineConfig
+	msg                  *model.MessageInstance
+	flows                map[string]*flow.CompiledFlowNode
+	appStore             store.AppStore
+	logStore             store.LogStore
+	messageStore         store.MessageStore
+	messageInstanceStore store.MessageInstanceStore
+	httpClient           *http.Client
 }
 
 func NewMessageInstance(
@@ -32,6 +33,7 @@ func NewMessageInstance(
 	appStore store.AppStore,
 	logStore store.LogStore,
 	messageStore store.MessageStore,
+	messageInstanceStore store.MessageInstanceStore,
 	httpClient *http.Client,
 ) (*MessageInstance, error) {
 	flows := make(map[string]*flow.CompiledFlowNode, len(msg.FlowSources))
@@ -47,13 +49,14 @@ func NewMessageInstance(
 	}
 
 	return &MessageInstance{
-		config:       config,
-		msg:          msg,
-		flows:        flows,
-		appStore:     appStore,
-		logStore:     logStore,
-		messageStore: messageStore,
-		httpClient:   httpClient,
+		config:               config,
+		msg:                  msg,
+		flows:                flows,
+		appStore:             appStore,
+		logStore:             logStore,
+		messageStore:         messageStore,
+		messageInstanceStore: messageInstanceStore,
+		httpClient:           httpClient,
 	}, nil
 }
 
@@ -77,7 +80,7 @@ func (c *MessageInstance) HandleEvent(appID string, session *state.State, event 
 		Discord:         NewDiscordProvider(appID, c.appStore, session),
 		Log:             NewLogProvider(appID, c.logStore),
 		HTTP:            NewHTTPProvider(c.httpClient),
-		MessageTemplate: NewMessageTemplateProvider(c.messageStore),
+		MessageTemplate: NewMessageTemplateProvider(c.messageStore, c.messageInstanceStore),
 		// TODO: Variable provider
 	}
 

--- a/kite-service/internal/db/postgres/message.go
+++ b/kite-service/internal/db/postgres/message.go
@@ -190,6 +190,18 @@ func (c *Client) MessageInstancesByMessage(ctx context.Context, messageID string
 	return instances, nil
 }
 
+func (c *Client) MessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) (*model.MessageInstance, error) {
+	row, err := c.Q.GetMessageInstanceByDiscordMessageId(ctx, discordMessageID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return rowToMessageInstance(row)
+}
+
 func (c *Client) CreateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error) {
 	flowSources, err := json.Marshal(instance.FlowSources)
 	if err != nil {

--- a/kite-service/internal/db/postgres/message.go
+++ b/kite-service/internal/db/postgres/message.go
@@ -172,8 +172,15 @@ func (c *Client) MessageInstance(ctx context.Context, messageID string, instance
 	return rowToMessageInstance(row)
 }
 
-func (c *Client) MessageInstancesByMessage(ctx context.Context, messageID string) ([]*model.MessageInstance, error) {
-	rows, err := c.Q.GetMessageInstancesByMessage(ctx, messageID)
+func (c *Client) MessageInstancesByMessage(ctx context.Context, messageID string, includeHidden bool) ([]*model.MessageInstance, error) {
+	var rows []pgmodel.MessageInstance
+	var err error
+
+	if includeHidden {
+		rows, err = c.Q.GetMessageInstancesByMessageWithHidden(ctx, messageID)
+	} else {
+		rows, err = c.Q.GetMessageInstancesByMessage(ctx, messageID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -213,6 +220,8 @@ func (c *Client) CreateMessageInstance(ctx context.Context, instance *model.Mess
 		DiscordGuildID:   instance.DiscordGuildID,
 		DiscordChannelID: instance.DiscordChannelID,
 		DiscordMessageID: instance.DiscordMessageID,
+		Ephemeral:        instance.Ephemeral,
+		Hidden:           instance.Hidden,
 		FlowSources:      flowSources,
 		CreatedAt:        pgtype.Timestamp{Time: instance.CreatedAt.UTC(), Valid: true},
 		UpdatedAt:        pgtype.Timestamp{Time: instance.UpdatedAt.UTC(), Valid: true},
@@ -285,6 +294,8 @@ func rowToMessageInstance(row pgmodel.MessageInstance) (*model.MessageInstance, 
 		DiscordGuildID:   row.DiscordGuildID,
 		DiscordChannelID: row.DiscordChannelID,
 		DiscordMessageID: row.DiscordMessageID,
+		Ephemeral:        row.Ephemeral,
+		Hidden:           row.Hidden,
 		FlowSources:      flowSources,
 		CreatedAt:        row.CreatedAt.Time,
 		UpdatedAt:        row.UpdatedAt.Time,

--- a/kite-service/internal/db/postgres/migrations/011_create_message_instances_table.up.sql
+++ b/kite-service/internal/db/postgres/migrations/011_create_message_instances_table.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS message_instances (
     discord_channel_id TEXT NOT NULL,
     discord_message_id TEXT NOT NULL UNIQUE,
     
-    flow_sources JSONB NOT NULL,
+    flow_sources JSONB NOT NULL, -- snapshot from the message when sent
 
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL

--- a/kite-service/internal/db/postgres/migrations/011_create_message_instances_table.up.sql
+++ b/kite-service/internal/db/postgres/migrations/011_create_message_instances_table.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS message_instances (
     discord_channel_id TEXT NOT NULL,
     discord_message_id TEXT NOT NULL UNIQUE,
     
-    flow_sources JSONB NOT NULL, -- map of flow source ids to flow source objects
+    flow_sources JSONB NOT NULL,
 
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP NOT NULL

--- a/kite-service/internal/db/postgres/pgmodel/messages.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/messages.sql.go
@@ -212,6 +212,28 @@ func (q *Queries) GetMessageInstance(ctx context.Context, arg GetMessageInstance
 	return i, err
 }
 
+const getMessageInstanceByDiscordMessageId = `-- name: GetMessageInstanceByDiscordMessageId :one
+SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE discord_message_id = $1
+`
+
+func (q *Queries) GetMessageInstanceByDiscordMessageId(ctx context.Context, discordMessageID string) (MessageInstance, error) {
+	row := q.db.QueryRow(ctx, getMessageInstanceByDiscordMessageId, discordMessageID)
+	var i MessageInstance
+	err := row.Scan(
+		&i.ID,
+		&i.MessageID,
+		&i.Hidden,
+		&i.Ephemeral,
+		&i.DiscordGuildID,
+		&i.DiscordChannelID,
+		&i.DiscordMessageID,
+		&i.FlowSources,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getMessageInstancesByMessage = `-- name: GetMessageInstancesByMessage :many
 SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC
 `

--- a/kite-service/internal/db/postgres/pgmodel/messages.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/messages.sql.go
@@ -87,11 +87,13 @@ INSERT INTO message_instances (
     discord_guild_id,
     discord_channel_id,
     discord_message_id,
+    ephemeral,
+    hidden,
     flow_sources,
     created_at,
     updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 ) RETURNING id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at
 `
 
@@ -100,6 +102,8 @@ type CreateMessageInstanceParams struct {
 	DiscordGuildID   string
 	DiscordChannelID string
 	DiscordMessageID string
+	Ephemeral        bool
+	Hidden           bool
 	FlowSources      []byte
 	CreatedAt        pgtype.Timestamp
 	UpdatedAt        pgtype.Timestamp
@@ -111,6 +115,8 @@ func (q *Queries) CreateMessageInstance(ctx context.Context, arg CreateMessageIn
 		arg.DiscordGuildID,
 		arg.DiscordChannelID,
 		arg.DiscordMessageID,
+		arg.Ephemeral,
+		arg.Hidden,
 		arg.FlowSources,
 		arg.CreatedAt,
 		arg.UpdatedAt,
@@ -235,11 +241,46 @@ func (q *Queries) GetMessageInstanceByDiscordMessageId(ctx context.Context, disc
 }
 
 const getMessageInstancesByMessage = `-- name: GetMessageInstancesByMessage :many
-SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC
+SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE message_id = $1 AND NOT hidden ORDER BY created_at DESC
 `
 
 func (q *Queries) GetMessageInstancesByMessage(ctx context.Context, messageID string) ([]MessageInstance, error) {
 	rows, err := q.db.Query(ctx, getMessageInstancesByMessage, messageID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []MessageInstance
+	for rows.Next() {
+		var i MessageInstance
+		if err := rows.Scan(
+			&i.ID,
+			&i.MessageID,
+			&i.Hidden,
+			&i.Ephemeral,
+			&i.DiscordGuildID,
+			&i.DiscordChannelID,
+			&i.DiscordMessageID,
+			&i.FlowSources,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getMessageInstancesByMessageWithHidden = `-- name: GetMessageInstancesByMessageWithHidden :many
+SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC
+`
+
+func (q *Queries) GetMessageInstancesByMessageWithHidden(ctx context.Context, messageID string) ([]MessageInstance, error) {
+	rows, err := q.db.Query(ctx, getMessageInstancesByMessageWithHidden, messageID)
 	if err != nil {
 		return nil, err
 	}

--- a/kite-service/internal/db/postgres/queries/messages.sql
+++ b/kite-service/internal/db/postgres/queries/messages.sql
@@ -54,6 +54,9 @@ SELECT * FROM message_instances WHERE id = $1 AND message_id = $2;
 -- name: GetMessageInstancesByMessage :many
 SELECT * FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC;
 
+-- name: GetMessageInstanceByDiscordMessageId :one
+SELECT * FROM message_instances WHERE discord_message_id = $1;
+
 -- name: UpdateMessageInstance :one
 UPDATE message_instances SET
     flow_sources = $3,

--- a/kite-service/internal/db/postgres/queries/messages.sql
+++ b/kite-service/internal/db/postgres/queries/messages.sql
@@ -41,17 +41,22 @@ INSERT INTO message_instances (
     discord_guild_id,
     discord_channel_id,
     discord_message_id,
+    ephemeral,
+    hidden,
     flow_sources,
     created_at,
     updated_at
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 ) RETURNING *;
 
 -- name: GetMessageInstance :one
 SELECT * FROM message_instances WHERE id = $1 AND message_id = $2;
 
 -- name: GetMessageInstancesByMessage :many
+SELECT * FROM message_instances WHERE message_id = $1 AND NOT hidden ORDER BY created_at DESC;
+
+-- name: GetMessageInstancesByMessageWithHidden :many
 SELECT * FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC;
 
 -- name: GetMessageInstanceByDiscordMessageId :one

--- a/kite-service/internal/model/message.go
+++ b/kite-service/internal/model/message.go
@@ -27,6 +27,8 @@ type MessageInstance struct {
 	DiscordGuildID   string
 	DiscordChannelID string
 	DiscordMessageID string
+	Ephemeral        bool
+	Hidden           bool
 	FlowSources      map[string]flow.FlowData
 	CreatedAt        time.Time
 	UpdatedAt        time.Time

--- a/kite-service/internal/store/message.go
+++ b/kite-service/internal/store/message.go
@@ -18,6 +18,7 @@ type MessageStore interface {
 type MessageInstanceStore interface {
 	MessageInstance(ctx context.Context, messageID string, instanceID uint64) (*model.MessageInstance, error)
 	MessageInstancesByMessage(ctx context.Context, messageID string) ([]*model.MessageInstance, error)
+	MessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) (*model.MessageInstance, error)
 	CreateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)
 	UpdateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)
 	DeleteMessageInstance(ctx context.Context, messageID string, instanceID uint64) error

--- a/kite-service/internal/store/message.go
+++ b/kite-service/internal/store/message.go
@@ -17,7 +17,7 @@ type MessageStore interface {
 
 type MessageInstanceStore interface {
 	MessageInstance(ctx context.Context, messageID string, instanceID uint64) (*model.MessageInstance, error)
-	MessageInstancesByMessage(ctx context.Context, messageID string) ([]*model.MessageInstance, error)
+	MessageInstancesByMessage(ctx context.Context, messageID string, includeHidden bool) ([]*model.MessageInstance, error)
 	MessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) (*model.MessageInstance, error)
 	CreateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)
 	UpdateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)

--- a/kite-service/pkg/flow/compile.go
+++ b/kite-service/pkg/flow/compile.go
@@ -13,6 +13,10 @@ func CompileCommand(data FlowData) (*CompiledFlowNode, error) {
 	return compile(data, FlowNodeTypeEntryCommand)
 }
 
+func CompileComponentButton(data FlowData) (*CompiledFlowNode, error) {
+	return compile(data, FlowNodeTypeEntryComponentButton)
+}
+
 func compile(data FlowData, entryType FlowNodeType) (*CompiledFlowNode, error) {
 	var entryNode *CompiledFlowNode
 	nodeMap := make(map[string]*CompiledFlowNode)

--- a/kite-service/pkg/flow/data.go
+++ b/kite-service/pkg/flow/data.go
@@ -25,8 +25,9 @@ func (d FlowData) Validate() error {
 type FlowNodeType string
 
 const (
-	FlowNodeTypeEntryCommand FlowNodeType = "entry_command"
-	FlowNodeTypeEntryEvent   FlowNodeType = "entry_event"
+	FlowNodeTypeEntryCommand         FlowNodeType = "entry_command"
+	FlowNodeTypeEntryEvent           FlowNodeType = "entry_event"
+	FlowNodeTypeEntryComponentButton FlowNodeType = "entry_component_button"
 
 	FlowNodeTypeOptionCommandArgument    FlowNodeType = "option_command_argument"
 	FlowNodeTypeOptionCommandPermissions FlowNodeType = "option_command_permissions"

--- a/kite-service/pkg/flow/execute.go
+++ b/kite-service/pkg/flow/execute.go
@@ -30,6 +30,8 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 		return n.executeChildren(ctx)
 	case FlowNodeTypeEntryEvent:
 		return n.executeChildren(ctx)
+	case FlowNodeTypeEntryComponentButton:
+		return n.executeChildren(ctx)
 	case FlowNodeTypeActionResponseCreate:
 		interaction := ctx.Data.Interaction()
 		if interaction == nil {

--- a/kite-service/pkg/flow/execute.go
+++ b/kite-service/pkg/flow/execute.go
@@ -90,6 +90,8 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 			}
 		}
 
+		// TODO: create message instance if message template was used
+
 		return n.executeChildren(ctx)
 	case FlowNodeTypeActionResponseEdit:
 		interaction := ctx.Data.Interaction()
@@ -122,8 +124,9 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 		var msg *discord.Message
 		if n.Data.MessageTarget == "" || n.Data.MessageTarget == "@original" {
 			msg, err = ctx.Discord.EditInteractionResponse(ctx, interaction.AppID, interaction.Token, api.EditInteractionResponseData{
-				Content: responseData.Content,
-				Embeds:  responseData.Embeds,
+				Content:    responseData.Content,
+				Embeds:     responseData.Embeds,
+				Components: responseData.Components,
 			})
 			if err != nil {
 				return traceError(n, err)

--- a/kite-service/pkg/flow/execute_test.go
+++ b/kite-service/pkg/flow/execute_test.go
@@ -84,9 +84,9 @@ type TestDiscordProvider struct {
 	response api.InteractionResponse
 }
 
-func (p *TestDiscordProvider) CreateInteractionResponse(ctx context.Context, interactionID discord.InteractionID, interactionToken string, response api.InteractionResponse) error {
+func (p *TestDiscordProvider) CreateInteractionResponse(ctx context.Context, interactionID discord.InteractionID, interactionToken string, response api.InteractionResponse) (*FlowInteractionResponseResource, error) {
 	p.response = response
-	return nil
+	return nil, nil
 }
 
 type TestContextData struct{}

--- a/kite-service/pkg/flow/provider.go
+++ b/kite-service/pkg/flow/provider.go
@@ -72,4 +72,5 @@ type FlowVariableProvider interface {
 
 type FlowMessageTemplateProvider interface {
 	MessageTemplate(ctx context.Context, id string) (*message.MessageData, error)
+	// TODO: add message instance to store mehtod
 }

--- a/kite-service/pkg/flow/provider.go
+++ b/kite-service/pkg/flow/provider.go
@@ -31,7 +31,7 @@ type FlowDiscordProvider interface {
 	Role(ctx context.Context, guildID discord.GuildID, roleID discord.RoleID) (*discord.Role, error)
 	Member(ctx context.Context, guildID discord.GuildID, userID discord.UserID) (*discord.Member, error)
 
-	CreateInteractionResponse(ctx context.Context, interactionID discord.InteractionID, interactionToken string, response api.InteractionResponse) error
+	CreateInteractionResponse(ctx context.Context, interactionID discord.InteractionID, interactionToken string, response api.InteractionResponse) (*FlowInteractionResponseResource, error)
 	EditInteractionResponse(ctx context.Context, applicationID discord.AppID, token string, response api.EditInteractionResponseData) (*discord.Message, error)
 	DeleteInteractionResponse(ctx context.Context, applicationID discord.AppID, token string) error
 	CreateInteractionFollowup(ctx context.Context, applicationID discord.AppID, token string, data api.InteractionResponseData) (*discord.Message, error)
@@ -56,6 +56,11 @@ type FlowDiscordProvider interface {
 	HasCreatedInteractionResponse(ctx context.Context, interactionID discord.InteractionID) (bool, error)
 }
 
+type FlowInteractionResponseResource struct {
+	Type    api.InteractionResponseType
+	Message *discord.Message
+}
+
 type FlowHTTPProvider interface {
 	HTTPRequest(ctx context.Context, req *http.Request) (*http.Response, error)
 }
@@ -72,5 +77,13 @@ type FlowVariableProvider interface {
 
 type FlowMessageTemplateProvider interface {
 	MessageTemplate(ctx context.Context, id string) (*message.MessageData, error)
-	// TODO: add message instance to store mehtod
+	LinkMessageTemplateInstance(ctx context.Context, instance FlowMessageTemplateInstance) error
+}
+
+type FlowMessageTemplateInstance struct {
+	MessageTemplateID string
+	MessageID         discord.MessageID
+	ChannelID         discord.ChannelID
+	GuildID           discord.GuildID
+	Ephemeral         bool
 }

--- a/kite-service/pkg/flow/provider_mock.go
+++ b/kite-service/pkg/flow/provider_mock.go
@@ -38,8 +38,8 @@ func (p *MockDiscordProvider) Member(ctx context.Context, guildID discord.GuildI
 	return nil, nil
 }
 
-func (p *MockDiscordProvider) CreateInteractionResponse(ctx context.Context, interactionID discord.InteractionID, interactionToken string, response api.InteractionResponse) error {
-	return nil
+func (p *MockDiscordProvider) CreateInteractionResponse(ctx context.Context, interactionID discord.InteractionID, interactionToken string, response api.InteractionResponse) (*FlowInteractionResponseResource, error) {
+	return nil, nil
 }
 
 func (p *MockDiscordProvider) EditInteractionResponse(ctx context.Context, applicationID discord.AppID, token string, response api.EditInteractionResponseData) (*discord.Message, error) {

--- a/kite-service/pkg/message/data.go
+++ b/kite-service/pkg/message/data.go
@@ -1,12 +1,15 @@
 package message
 
-import "time"
+import (
+	"time"
+)
 
 type MessageData struct {
 	Content     string              `json:"content,omitempty"`
 	Flags       int                 `json:"flags,omitempty"`
 	Attachments []MessageAttachment `json:"attachments,omitempty"`
 	Embeds      []EmbedData         `json:"embeds,omitempty"`
+	Components  []ComponentRowData  `json:"components,omitempty"`
 }
 
 type MessageAttachment struct {
@@ -14,6 +17,8 @@ type MessageAttachment struct {
 }
 
 type EmbedData struct {
+	ID int `json:"id,omitempty"`
+
 	Title       string              `json:"title,omitempty"`
 	Description string              `json:"description,omitempty"`
 	URL         string              `json:"url,omitempty"`
@@ -46,7 +51,53 @@ type EmbedAuthorData struct {
 }
 
 type EmbedFieldData struct {
+	ID int `json:"id,omitempty"`
+
 	Name   string `json:"name,omitempty"`
 	Value  string `json:"value,omitempty"`
 	Inline bool   `json:"inline,omitempty"`
+}
+
+type ComponentRowData struct {
+	ID int `json:"id,omitempty"`
+
+	Components []ComponentData `json:"components,omitempty"`
+}
+
+type ComponentData struct {
+	ID int `json:"id,omitempty"`
+
+	Type     int  `json:"type,omitempty"`
+	Disabled bool `json:"disabled,omitempty"`
+
+	// Button
+	Style int                 `json:"style,omitempty"`
+	Label string              `json:"label,omitempty"`
+	Emoji *ComponentEmojiData `json:"emoji,omitempty"`
+	URL   string              `json:"url,omitempty"`
+
+	// Select Menu
+	Placeholder string                      `json:"placeholder,omitempty"`
+	MinValues   int                         `json:"min_values,omitempty"`
+	MaxValues   int                         `json:"max_values,omitempty"`
+	Options     []ComponentSelectOptionData `json:"options,omitempty"`
+
+	FlowSourceID string `json:"flow_source_id,omitempty"`
+}
+
+type ComponentSelectOptionData struct {
+	ID int `json:"id,omitempty"`
+
+	Label       string              `json:"label,omitempty"`
+	Description string              `json:"description,omitempty"`
+	Emoji       *ComponentEmojiData `json:"emoji,omitempty"`
+	Default     bool                `json:"default,omitempty"`
+
+	FlowSourceID string `json:"flow_source_id,omitempty"`
+}
+
+type ComponentEmojiData struct {
+	Name     string `json:"name,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Animated bool   `json:"animated,omitempty"`
 }

--- a/kite-web/package-lock.json
+++ b/kite-web/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.1",
+        "@emoji-mart/data": "^1.2.1",
+        "@emoji-mart/react": "^1.1.1",
         "@formkit/auto-animate": "^0.8.2",
         "@hookform/resolvers": "^3.6.0",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -49,6 +51,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "emoji-mart": "^5.6.0",
         "highlight.js": "^11.10.0",
         "immer": "^10.1.1",
         "input-otp": "^1.2.4",
@@ -203,6 +206,20 @@
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw=="
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
+        "react": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3911,6 +3928,11 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/emoji-mart": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/kite-web/package.json
+++ b/kite-web/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.1",
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
     "@formkit/auto-animate": "^0.8.2",
     "@hookform/resolvers": "^3.6.0",
     "@radix-ui/react-accordion": "^1.2.0",
@@ -50,6 +52,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "emoji-mart": "^5.6.0",
     "highlight.js": "^11.10.0",
     "immer": "^10.1.1",
     "input-otp": "^1.2.4",

--- a/kite-web/src/components/app/MessageCreateDialog.tsx
+++ b/kite-web/src/components/app/MessageCreateDialog.tsx
@@ -51,6 +51,7 @@ const createDefaultMessage = (name: string) => ({
   actions: {},
 });
 
+// TODO: forwardref
 export default function MessageCreateDialog({
   children,
   onMessageCreated,

--- a/kite-web/src/components/common/EmojiPicker.tsx
+++ b/kite-web/src/components/common/EmojiPicker.tsx
@@ -1,0 +1,47 @@
+import Picker from "@emoji-mart/react";
+import { ReactNode } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface Props {
+  onEmojiSelect: (emoji: string) => void;
+  children: ReactNode;
+}
+
+export default function EmojiPicker({ onEmojiSelect, children }: Props) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="p-0 border-none">
+        <Picker
+          data={async () => {
+            const response = await fetch(
+              "https://cdn.jsdelivr.net/npm/@emoji-mart/data/sets/15/twitter.json"
+            );
+            return response.json();
+          }}
+          onEmojiSelect={(data: any) => onEmojiSelect(data.native)}
+          categories={[
+            "frequent",
+            "people",
+            "nature",
+            "foods",
+            "activity",
+            "places",
+            "objects",
+            "symbols",
+            "flags",
+          ]}
+          theme="dark"
+          set="twitter"
+          getSpritesheetURL={() => {
+            return "https://cdn.jsdelivr.net/npm/emoji-datasource-twitter@15.0.0/img/twitter/sheets-256/64.png";
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/kite-web/src/components/common/EmojiPicker.tsx
+++ b/kite-web/src/components/common/EmojiPicker.tsx
@@ -1,5 +1,5 @@
 import Picker from "@emoji-mart/react";
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import {
   Popover,
   PopoverContent,
@@ -12,8 +12,10 @@ interface Props {
 }
 
 export default function EmojiPicker({ onEmojiSelect, children }: Props) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="p-0 border-none">
         <Picker
@@ -23,7 +25,10 @@ export default function EmojiPicker({ onEmojiSelect, children }: Props) {
             );
             return response.json();
           }}
-          onEmojiSelect={(data: any) => onEmojiSelect(data.native)}
+          onEmojiSelect={(data: any) => {
+            onEmojiSelect(data.native);
+            setOpen(false);
+          }}
           categories={[
             "frequent",
             "people",

--- a/kite-web/src/components/flow/Flow.tsx
+++ b/kite-web/src/components/flow/Flow.tsx
@@ -1,35 +1,17 @@
-import { FlowData, NodeType } from "@/lib/flow/data";
+import { FlowData } from "@/lib/flow/data";
 import FlowEditor from "./FlowEditor";
-import FlowNav from "./FlowNav";
 import FlowNodeEditor from "./FlowNodeEditor";
 import FlowNodeExplorer from "./FlowNodeExplorer";
-import {
-  OnSelectionChangeParams,
-  ReactFlowProvider,
-  useReactFlow,
-} from "@xyflow/react";
+import { OnSelectionChangeParams } from "@xyflow/react";
 import { useCallback, useState } from "react";
 
 interface Props {
   flowData: FlowData;
-  hasUnsavedChanges: boolean;
   onChange: () => void;
-  isSaving: boolean;
-  onSave: (data: FlowData) => void;
-  onExit: () => void;
 }
 
-function InnerFlow({
-  flowData,
-  hasUnsavedChanges,
-  onChange,
-  isSaving,
-  onSave,
-  onExit,
-}: Props) {
+export default function Flow({ flowData, onChange }: Props) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-
-  const { getNodes, getEdges } = useReactFlow<NodeType>();
 
   const onSelectionChange = useCallback(
     ({ nodes }: OnSelectionChangeParams) => {
@@ -42,44 +24,19 @@ function InnerFlow({
     []
   );
 
-  const save = useCallback(() => {
-    onSave({
-      nodes: getNodes(),
-      edges: getEdges(),
-    });
-  }, [getNodes, getEdges, onSave]);
-
   return (
-    <div className="h-[100dvh] w-[100dvw] flex flex-col">
+    <div className="flex flex-auto overflow-y-hidden relative">
       <div className="flex-none">
-        <FlowNav
-          hasUnsavedChanges={hasUnsavedChanges}
-          isSaving={isSaving}
-          onSave={save}
-          onExit={onExit}
+        <FlowNodeExplorer />
+        {selectedNodeId && <FlowNodeEditor nodeId={selectedNodeId} />}
+      </div>
+      <div className="flex-auto">
+        <FlowEditor
+          initialData={flowData}
+          onChange={onChange}
+          onSelectionChange={onSelectionChange}
         />
       </div>
-      <div className="flex flex-auto overflow-y-hidden relative">
-        <div className="flex-none">
-          <FlowNodeExplorer />
-          {selectedNodeId && <FlowNodeEditor nodeId={selectedNodeId} />}
-        </div>
-        <div className="flex-auto">
-          <FlowEditor
-            initialData={flowData}
-            onChange={onChange}
-            onSelectionChange={onSelectionChange}
-          />
-        </div>
-      </div>
     </div>
-  );
-}
-
-export default function Flow(props: Props) {
-  return (
-    <ReactFlowProvider>
-      <InnerFlow {...props} />
-    </ReactFlowProvider>
   );
 }

--- a/kite-web/src/components/flow/FlowDialog.tsx
+++ b/kite-web/src/components/flow/FlowDialog.tsx
@@ -1,0 +1,66 @@
+import { FlowData, NodeType } from "@/lib/flow/data";
+import { ReactFlowProvider, useReactFlow } from "@xyflow/react";
+import { useCallback, useRef } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import Flow from "./Flow";
+
+function InnerFlowDialog({
+  flowData,
+  onChange,
+}: {
+  flowData: FlowData;
+  onChange: (d: FlowData) => void;
+}) {
+  const { getNodes, getEdges } = useReactFlow<NodeType>();
+
+  const handleChange = useCallback(() => {
+    onChange({
+      nodes: getNodes(),
+      edges: getEdges(),
+    });
+  }, [getNodes, getEdges, onChange]);
+
+  return <Flow flowData={flowData} onChange={handleChange} />;
+}
+
+export default function FlowDialog({
+  children,
+  onClose,
+  flowData,
+}: {
+  flowData: FlowData;
+  onClose: (data: FlowData) => void;
+  children: React.ReactNode;
+}) {
+  const dataRef = useRef(flowData);
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose(dataRef.current);
+      }
+    },
+    [onClose]
+  );
+
+  const onChange = useCallback((data: FlowData) => {
+    dataRef.current = data;
+  }, []);
+
+  return (
+    <Dialog onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="h-[90dvh] max-w-[90dvw] xl:max-w-7xl p-0">
+        <ReactFlowProvider>
+          <DialogTitle className="hidden">Flow Editor</DialogTitle>
+          <InnerFlowDialog flowData={flowData} onChange={onChange} />
+        </ReactFlowProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/kite-web/src/components/flow/FlowDialog.tsx
+++ b/kite-web/src/components/flow/FlowDialog.tsx
@@ -1,6 +1,6 @@
 import { FlowData, NodeType } from "@/lib/flow/data";
 import { ReactFlowProvider, useReactFlow } from "@xyflow/react";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -52,13 +52,21 @@ export default function FlowDialog({
     dataRef.current = data;
   }, []);
 
+  const [isAnimating, setIsAnimating] = useState(false);
+
   return (
     <Dialog onOpenChange={onOpenChange}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="h-[90dvh] max-w-[90dvw] xl:max-w-7xl p-0">
+      <DialogContent
+        className="h-[90dvh] w-full max-w-[90dvw] xl:max-w-7xl p-0"
+        onAnimationEnd={() => setIsAnimating(false)}
+        onAnimationStart={() => setIsAnimating(true)}
+      >
         <ReactFlowProvider>
           <DialogTitle className="hidden">Flow Editor</DialogTitle>
-          <InnerFlowDialog flowData={flowData} onChange={onChange} />
+          {isAnimating ? null : (
+            <InnerFlowDialog flowData={flowData} onChange={onChange} />
+          )}
         </ReactFlowProvider>
       </DialogContent>
     </Dialog>

--- a/kite-web/src/components/flow/FlowNodeEditor.tsx
+++ b/kite-web/src/components/flow/FlowNodeEditor.tsx
@@ -597,7 +597,7 @@ function MessageTemplateInput({ data, updateData, errors }: InputProps) {
       />
       {data.message_template_id ? (
         <Tooltip>
-          <TooltipTrigger>
+          <TooltipTrigger asChild>
             <Button variant="outline" size="icon" asChild>
               <Link
                 href={{
@@ -614,7 +614,7 @@ function MessageTemplateInput({ data, updateData, errors }: InputProps) {
         </Tooltip>
       ) : (
         <Tooltip>
-          <TooltipTrigger>
+          <TooltipTrigger asChild>
             <MessageCreateDialog
               onMessageCreated={(v) => updateData({ message_template_id: v })}
             >

--- a/kite-web/src/components/flow/FlowNodeEntryEvent.tsx
+++ b/kite-web/src/components/flow/FlowNodeEntryEvent.tsx
@@ -1,14 +1,12 @@
 import { Position } from "@xyflow/react";
 import { NodeProps } from "../../lib/flow/data";
 import FlowNodeBase from "./FlowNodeBase";
-import FlowNodeMarkers from "./FlowNodeMarkers";
 import FlowNodeHandle from "./FlowNodeHandle";
 
 export default function FlowNodeEntryEvent(props: NodeProps) {
   return (
     <FlowNodeBase {...props} highlight={true} showConnectedMarker={false}>
       <FlowNodeHandle type="source" position={Position.Bottom} />
-      <FlowNodeMarkers id={props.id} type={props.type} data={props.data} />
     </FlowNodeBase>
   );
 }

--- a/kite-web/src/components/flow/FlowPage.tsx
+++ b/kite-web/src/components/flow/FlowPage.tsx
@@ -1,0 +1,54 @@
+import { FlowData, NodeType } from "@/lib/flow/data";
+import FlowNav from "./FlowNav";
+import { ReactFlowProvider, useReactFlow } from "@xyflow/react";
+import { useCallback } from "react";
+import Flow from "./Flow";
+
+interface Props {
+  flowData: FlowData;
+  hasUnsavedChanges: boolean;
+  onChange: () => void;
+  isSaving: boolean;
+  onSave: (data: FlowData) => void;
+  onExit: () => void;
+}
+
+function InnerFlowPage({
+  flowData,
+  hasUnsavedChanges,
+  onChange,
+  isSaving,
+  onSave,
+  onExit,
+}: Props) {
+  const { getNodes, getEdges } = useReactFlow<NodeType>();
+
+  const save = useCallback(() => {
+    onSave({
+      nodes: getNodes(),
+      edges: getEdges(),
+    });
+  }, [getNodes, getEdges, onSave]);
+
+  return (
+    <div className="h-[100dvh] w-[100dvw] flex flex-col">
+      <div className="flex-none">
+        <FlowNav
+          hasUnsavedChanges={hasUnsavedChanges}
+          isSaving={isSaving}
+          onSave={save}
+          onExit={onExit}
+        />
+      </div>
+      <Flow flowData={flowData} onChange={onChange} />
+    </div>
+  );
+}
+
+export default function FlowPage(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <InnerFlowPage {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/kite-web/src/components/flow/FlowPreview.tsx
+++ b/kite-web/src/components/flow/FlowPreview.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@/lib/utils";
+import { edgeTypes, nodeTypes } from "@/lib/flow/components";
+import { ReactFlow } from "@xyflow/react";
+import { useHookedTheme } from "@/lib/hooks/theme";
+import "@xyflow/react/dist/base.css";
+
+const initialNodes = [
+  {
+    id: "1",
+    position: { x: 0, y: 0 },
+    data: { name: "ban", description: "Ban a user" },
+    type: "entry_command",
+  },
+];
+
+export default function FlowPreview({
+  className,
+  onClick,
+}: {
+  className?: string;
+  onClick: () => void;
+}) {
+  const { theme } = useHookedTheme();
+
+  return (
+    <div
+      className={cn("bg-muted/50 rounded-sm nowheel cursor-pointer", className)}
+      onClick={onClick}
+      role="button"
+    >
+      <ReactFlow
+        nodes={initialNodes}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        elementsSelectable={false}
+        nodesConnectable={false}
+        nodesDraggable={false}
+        connectOnClick={false}
+        draggable={false}
+        panOnDrag={false}
+        zoomOnScroll={false}
+        zoomOnPinch={false}
+        colorMode={theme === "dark" ? "dark" : "light"}
+        className="!bg-transparent hover:animate-shake"
+        proOptions={{
+          hideAttribution: true,
+        }}
+        fitView
+      />
+    </div>
+  );
+}

--- a/kite-web/src/components/flow/FlowPreview.tsx
+++ b/kite-web/src/components/flow/FlowPreview.tsx
@@ -3,23 +3,24 @@ import { edgeTypes, nodeTypes } from "@/lib/flow/components";
 import { ReactFlow } from "@xyflow/react";
 import { useHookedTheme } from "@/lib/hooks/theme";
 import "@xyflow/react/dist/base.css";
+import { forwardRef } from "react";
 
 const initialNodes = [
   {
     id: "1",
     position: { x: 0, y: 0 },
-    data: { name: "ban", description: "Ban a user" },
-    type: "entry_command",
+    data: { event_type: "" },
+    type: "entry_event",
   },
 ];
 
-export default function FlowPreview({
-  className,
-  onClick,
-}: {
-  className?: string;
-  onClick: () => void;
-}) {
+const FlowPreview = forwardRef<
+  HTMLDivElement,
+  {
+    className?: string;
+    onClick: () => void;
+  }
+>(({ className, onClick }, ref) => {
   const { theme } = useHookedTheme();
 
   return (
@@ -27,6 +28,7 @@ export default function FlowPreview({
       className={cn("bg-muted/50 rounded-sm nowheel cursor-pointer", className)}
       onClick={onClick}
       role="button"
+      ref={ref}
     >
       <ReactFlow
         nodes={initialNodes}
@@ -49,4 +51,7 @@ export default function FlowPreview({
       />
     </div>
   );
-}
+});
+
+FlowPreview.displayName = "FlowPreview";
+export default FlowPreview;

--- a/kite-web/src/components/flow/FlowPreview.tsx
+++ b/kite-web/src/components/flow/FlowPreview.tsx
@@ -9,8 +9,8 @@ const initialNodes = [
   {
     id: "1",
     position: { x: 0, y: 0 },
-    data: { event_type: "" },
-    type: "entry_event",
+    data: {},
+    type: "entry_component_button",
   },
 ];
 

--- a/kite-web/src/components/message/MessageAttachment.tsx
+++ b/kite-web/src/components/message/MessageAttachment.tsx
@@ -6,7 +6,6 @@ import { Card } from "../ui/card";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
 import { PaperclipIcon, TrashIcon } from "lucide-react";
-import { getApiUrl } from "@/lib/api/client";
 import { useCallback, useMemo } from "react";
 import { useCurrentMessage } from "@/lib/message/state";
 

--- a/kite-web/src/components/message/MessageAttachmentSection.tsx
+++ b/kite-web/src/components/message/MessageAttachmentSection.tsx
@@ -7,7 +7,6 @@ import { ChangeEvent, useCallback, useRef } from "react";
 import { useAssetCreateMutation } from "@/lib/api/mutations";
 import { useAppId } from "@/lib/hooks/params";
 import { toast } from "sonner";
-import AutoAnimate from "../common/AutoAnimate";
 
 export default function MessageAttachmentSection() {
   const attachments = useCurrentMessage(
@@ -44,38 +43,38 @@ export default function MessageAttachmentSection() {
         },
       });
     },
-    [inputRef, createMutation, addAttachment]
+    [createMutation, addAttachment]
   );
 
   return (
     <CollapsibleSection
       title="Attachments"
-      defaultOpen={false}
+      valiationPathPrefix="attachments"
       className="space-y-4"
     >
-      <AutoAnimate className="flex flex-wrap gap-4">
+      <div className="flex flex-wrap gap-4">
         {attachments.map((id, i) => (
           <MessageAttachment key={id} attachmentIndex={i} assetId={id} />
         ))}
-      </AutoAnimate>
+      </div>
       <div className="space-x-3">
-        <input
-          type="file"
-          className="hidden"
-          ref={inputRef}
-          onChange={onFileUpload}
-        />
-
         <Button
           onClick={() => inputRef.current?.click()}
-          disabled={!!inputRef.current?.value}
+          disabled={!!inputRef.current?.value || attachments.length >= 10}
         >
           Add Attachment
         </Button>
-        <Button onClick={clearAttachments} variant="destructive">
+        <Button onClick={clearAttachments} variant="outline">
           Clear Attachments
         </Button>
       </div>
+
+      <input
+        type="file"
+        className="hidden"
+        ref={inputRef}
+        onChange={onFileUpload}
+      />
     </CollapsibleSection>
   );
 }

--- a/kite-web/src/components/message/MessageCollapsibleSection.tsx
+++ b/kite-web/src/components/message/MessageCollapsibleSection.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useState } from "react";
 import { ChevronRightIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import MessageValidationErrorIndicator from "./MessageValidationErrorMarker";
-import AutoAnimate from "../common/AutoAnimate";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 
 export default function MessageCollapsibleSection({
@@ -15,6 +14,7 @@ export default function MessageCollapsibleSection({
   valiationPathPrefix,
   actions,
   className,
+  animate = true,
 }: {
   children: ReactNode;
   title: string;
@@ -23,6 +23,7 @@ export default function MessageCollapsibleSection({
   valiationPathPrefix?: string | string[];
   actions?: ReactNode;
   className?: string;
+  animate?: boolean;
 }) {
   const [open, setOpen] = useState(defaultOpen);
 
@@ -71,7 +72,10 @@ export default function MessageCollapsibleSection({
           <div className="flex-none flex items-center space-x-3">{actions}</div>
         )}
       </div>
-      <CollapsibleContent className={cn("mt-3", className)} ref={parent}>
+      <CollapsibleContent
+        className={cn("mt-3", className)}
+        ref={animate ? parent : null}
+      >
         {children}
       </CollapsibleContent>
     </Collapsible>

--- a/kite-web/src/components/message/MessageComponentButton.tsx
+++ b/kite-web/src/components/message/MessageComponentButton.tsx
@@ -1,0 +1,13 @@
+export default function MessageComponentButton({
+  rowIndex,
+  rowId,
+  compIndex,
+  compId,
+}: {
+  rowIndex: number;
+  rowId: number;
+  compIndex: number;
+  compId: number;
+}) {
+  return <div></div>;
+}

--- a/kite-web/src/components/message/MessageComponentButton.tsx
+++ b/kite-web/src/components/message/MessageComponentButton.tsx
@@ -30,7 +30,7 @@ const initialFlow = {
       id: getUniqueId().toString(),
       position: { x: 0, y: 0 },
       data: {},
-      type: "entry_event",
+      type: "entry_component_button",
     },
   ],
   edges: [],

--- a/kite-web/src/components/message/MessageComponentButton.tsx
+++ b/kite-web/src/components/message/MessageComponentButton.tsx
@@ -1,3 +1,26 @@
+import { useCurrentMessage } from "@/lib/message/state";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "../ui/card";
+import MessageCollapsibleSection from "./MessageCollapsibleSection";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CopyIcon,
+  TrashIcon,
+} from "lucide-react";
+import MessageInput from "./MessageInput";
+import { Button } from "../ui/button";
+import { useMemo } from "react";
+import MessageEmojiPicker from "./MessageEmojiPicker";
+
+const buttonColors = {
+  1: "#5865F2",
+  2: "#4E5058",
+  3: "#57F287",
+  4: "#ED4245",
+  5: "#4E5058",
+};
+
 export default function MessageComponentButton({
   rowIndex,
   rowId,
@@ -9,5 +32,161 @@ export default function MessageComponentButton({
   compIndex: number;
   compId: number;
 }) {
-  return <div></div>;
+  const buttonCount = useCurrentMessage(
+    (state) => state.components[rowIndex].components.length
+  );
+
+  const [label, setLabel] = useCurrentMessage(
+    useShallow((state) => [
+      state.getButton(rowIndex, compIndex)?.label || "",
+      state.setButtonLabel,
+    ])
+  );
+
+  const [emoji, setEmoji] = useCurrentMessage(
+    useShallow((state) => [
+      state.getButton(rowIndex, compIndex)?.emoji,
+      state.setButtonEmoji,
+    ])
+  );
+
+  const [url, setUrl] = useCurrentMessage(
+    useShallow((state) => {
+      const button = state.getButton(rowIndex, compIndex);
+      return [button?.style === 5 ? button.url : "", state.setButtonUrl];
+    })
+  );
+
+  const [style, setStyle] = useCurrentMessage(
+    useShallow((state) => [
+      state.getButton(rowIndex, compIndex)?.style,
+      state.setButtonStyle,
+    ])
+  );
+
+  const [disabled, setDisabled] = useCurrentMessage((state) => [
+    state.getButton(rowIndex, compIndex)?.disabled,
+    state.setButtonDisabled,
+  ]);
+
+  const [moveUp, moveDown, duplicate, remove] = useCurrentMessage(
+    useShallow((state) => [
+      state.moveButtonUp,
+      state.moveButtonDown,
+      state.duplicateButton,
+      state.deleteButton,
+    ])
+  );
+
+  const color = useMemo(
+    () => (style ? buttonColors[style] : buttonColors[1]),
+    [style]
+  );
+
+  if (!style) {
+    // This is not a button (should never happen)
+    return <div></div>;
+  }
+
+  return (
+    <Card
+      className="p-3 border-l-[3px] rounded-l-[5px]"
+      style={{
+        borderLeftColor: color,
+      }}
+    >
+      <MessageCollapsibleSection
+        title={`Button ${compIndex + 1}`}
+        size="md"
+        valiationPathPrefix={`components.${rowIndex}.components.${compIndex}`}
+        className="space-y-3"
+        actions={
+          <>
+            {compIndex > 0 && (
+              <ChevronUpIcon
+                className="h-5 w-5"
+                onClick={() => moveUp(rowIndex, compIndex)}
+                role="button"
+              />
+            )}
+            {compIndex < buttonCount - 1 && (
+              <ChevronDownIcon
+                className="h-5 w-5"
+                onClick={() => moveDown(rowIndex, compIndex)}
+                role="button"
+              />
+            )}
+            {buttonCount < 5 && (
+              <CopyIcon
+                className="h-4 w-4"
+                onClick={() => duplicate(rowIndex, compIndex)}
+                role="button"
+              />
+            )}
+            <TrashIcon
+              className="h-4 w-4"
+              onClick={() => remove(rowIndex, compIndex)}
+              role="button"
+            />
+          </>
+        }
+      >
+        <div className="flex space-x-3">
+          <div className="w-full">
+            <MessageInput
+              type="select"
+              label="Style"
+              value={style.toString()}
+              options={[
+                { label: "Blurple", value: "1" },
+                { label: "Gray", value: "2" },
+                { label: "Green", value: "3" },
+                { label: "Red", value: "4" },
+                { label: "Direct Link", value: "5" },
+              ]}
+              placeholder="Select a button style"
+              onChange={(v) =>
+                setStyle(rowIndex, compIndex, parseInt(v) as any)
+              }
+              validationPath={`components.${rowIndex}.components.${compIndex}.style`}
+            />
+          </div>
+          <div className="flex-none">
+            <MessageInput
+              type="toggle"
+              label="Disabled"
+              value={disabled || false}
+              onChange={(v) => setDisabled(rowIndex, compIndex, v || undefined)}
+              validationPath={`components.${rowIndex}.components.${compIndex}.disabled`}
+            />
+          </div>
+        </div>
+        <div className="flex space-x-3">
+          <MessageEmojiPicker
+            emoji={emoji}
+            onChange={(v) => setEmoji(rowIndex, compIndex, v)}
+          />
+          <MessageInput
+            type="text"
+            label="Label"
+            maxLength={80}
+            value={label}
+            onChange={(v) => setLabel(rowIndex, compIndex, v)}
+            validationPath={`components.${rowIndex}.components.${compIndex}.label`}
+          />
+        </div>
+        {style === 5 ? (
+          <MessageInput
+            type="url"
+            label="URL"
+            value={url}
+            onChange={(v) => setUrl(rowIndex, compIndex, v)}
+            validationPath={`components.${rowIndex}.components.${compIndex}.url`}
+          />
+        ) : (
+          <Button>Edit Flow</Button>
+        )}
+      </MessageCollapsibleSection>
+    </Card>
+  );
 }

--- a/kite-web/src/components/message/MessageComponentButton.tsx
+++ b/kite-web/src/components/message/MessageComponentButton.tsx
@@ -225,7 +225,7 @@ export default function MessageComponentButton({
                 flowData={flowData || initialFlow}
                 onClose={onFlowDialogClose}
               >
-                <FlowPreview className="h-64 w-full" onClick={() => {}} />
+                <FlowPreview className="h-64 p-16 w-full" onClick={() => {}} />
               </FlowDialog>
             </MessageCollapsibleSection>
           </>

--- a/kite-web/src/components/message/MessageComponentButton.tsx
+++ b/kite-web/src/components/message/MessageComponentButton.tsx
@@ -9,9 +9,9 @@ import {
   TrashIcon,
 } from "lucide-react";
 import MessageInput from "./MessageInput";
-import { Button } from "../ui/button";
 import { useMemo } from "react";
 import MessageEmojiPicker from "./MessageEmojiPicker";
+import FlowPreview from "../flow/FlowPreview";
 
 const buttonColors = {
   1: "#5865F2",
@@ -100,6 +100,7 @@ export default function MessageComponentButton({
         size="md"
         valiationPathPrefix={`components.${rowIndex}.components.${compIndex}`}
         className="space-y-3"
+        animate={false}
         actions={
           <>
             {compIndex > 0 && (
@@ -184,7 +185,7 @@ export default function MessageComponentButton({
             validationPath={`components.${rowIndex}.components.${compIndex}.url`}
           />
         ) : (
-          <Button>Edit Flow</Button>
+          <FlowPreview className="h-64 w-full" onClick={() => {}} />
         )}
       </MessageCollapsibleSection>
     </Card>

--- a/kite-web/src/components/message/MessageComponentRow.tsx
+++ b/kite-web/src/components/message/MessageComponentRow.tsx
@@ -91,7 +91,7 @@ export default function MessageComponentRow({
                   compId={id}
                 ></MessageComponentButton>
               ) : (
-                <div></div>
+                <div key={id}></div>
               )
             )}
             <div className="space-x-3">
@@ -121,7 +121,7 @@ export default function MessageComponentRow({
           </>
         ) : (
           <div className="text-muted-foreground">
-            select menus aren't supported yet
+            select menus aren&apos;t supported yet
           </div>
         )}
       </MessageCollapsibleSection>

--- a/kite-web/src/components/message/MessageComponentRow.tsx
+++ b/kite-web/src/components/message/MessageComponentRow.tsx
@@ -102,7 +102,7 @@ export default function MessageComponentRow({
                     type: 2,
                     style: 2,
                     label: "",
-                    action_set_id: getUniqueId().toString(), // TODO: refactor this for flow_source_id
+                    flow_source_id: getUniqueId().toString(), // TODO: refactor this for flow_source_id
                   })
                 }
                 size="sm"

--- a/kite-web/src/components/message/MessageComponentRow.tsx
+++ b/kite-web/src/components/message/MessageComponentRow.tsx
@@ -77,7 +77,7 @@ export default function MessageComponentRow({
             />
           </>
         }
-        className="space-y-5"
+        className="space-y-3"
       >
         {isButtonRow ? (
           <>

--- a/kite-web/src/components/message/MessageComponentRow.tsx
+++ b/kite-web/src/components/message/MessageComponentRow.tsx
@@ -1,0 +1,130 @@
+import { useCurrentMessage } from "@/lib/message/state";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "../ui/card";
+import MessageCollapsibleSection from "./MessageCollapsibleSection";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CopyIcon,
+  TrashIcon,
+} from "lucide-react";
+import { Button } from "../ui/button";
+import { getUniqueId } from "@/lib/utils";
+import MessageComponentButton from "./MessageComponentButton";
+
+export default function MessageComponentRow({
+  rowIndex,
+  rowId,
+}: {
+  rowIndex: number;
+  rowId: number;
+}) {
+  const rowCount = useCurrentMessage((state) => state.components.length);
+  const components = useCurrentMessage(
+    useShallow((state) =>
+      state.components[rowIndex].components.map((c) => c.id)
+    )
+  );
+  const isButtonRow = useCurrentMessage((state) =>
+    state.components[rowIndex].components.every((c) => c.type === 2)
+  );
+  const [moveUp, moveDown, duplicate, remove] = useCurrentMessage(
+    useShallow((state) => [
+      state.moveComponentRowUp,
+      state.moveComponentRowDown,
+      state.duplicateComponentRow,
+      state.deleteComponentRow,
+    ])
+  );
+
+  const [addButton, clearButtons] = useCurrentMessage(
+    useShallow((state) => [state.addButton, state.clearButtons])
+  );
+
+  return (
+    <Card className="px-4 py-3">
+      <MessageCollapsibleSection
+        title={`Row ${rowIndex + 1}`}
+        size="lg"
+        valiationPathPrefix={`components.${rowIndex}`}
+        actions={
+          <>
+            {rowIndex > 0 && (
+              <ChevronUpIcon
+                className="h-6 w-6"
+                onClick={() => moveUp(rowIndex)}
+                role="button"
+              />
+            )}
+            {rowIndex < rowCount - 1 && (
+              <ChevronDownIcon
+                className="h-6 w-6"
+                onClick={() => moveDown(rowIndex)}
+                role="button"
+              />
+            )}
+            {rowCount < 10 && (
+              <CopyIcon
+                className="h-5 w-5"
+                onClick={() => duplicate(rowIndex)}
+                role="button"
+              />
+            )}
+            <TrashIcon
+              className="h-5 w-5"
+              onClick={() => remove(rowIndex)}
+              role="button"
+            />
+          </>
+        }
+        className="space-y-5"
+      >
+        {isButtonRow ? (
+          <>
+            {components.map((id, i) =>
+              isButtonRow ? (
+                <MessageComponentButton
+                  key={id}
+                  rowIndex={rowIndex}
+                  rowId={rowId}
+                  compIndex={i}
+                  compId={id}
+                ></MessageComponentButton>
+              ) : (
+                <div></div>
+              )
+            )}
+            <div className="space-x-3">
+              <Button
+                onClick={() =>
+                  addButton(rowIndex, {
+                    id: getUniqueId(),
+                    type: 2,
+                    style: 2,
+                    label: "",
+                    action_set_id: getUniqueId().toString(), // TODO: refactor this for flow_source_id
+                  })
+                }
+                size="sm"
+                disabled={components.length >= 5}
+              >
+                Add Button
+              </Button>
+              <Button
+                onClick={() => clearButtons(rowIndex)}
+                variant="destructive"
+                size="sm"
+              >
+                Clear Buttons
+              </Button>
+            </div>
+          </>
+        ) : (
+          <div className="text-muted-foreground">
+            select menus aren't supported yet
+          </div>
+        )}
+      </MessageCollapsibleSection>
+    </Card>
+  );
+}

--- a/kite-web/src/components/message/MessageComponentsSection.tsx
+++ b/kite-web/src/components/message/MessageComponentsSection.tsx
@@ -1,0 +1,59 @@
+import { useCurrentMessage } from "@/lib/message/state";
+import CollapsibleSection from "./MessageCollapsibleSection";
+import { useShallow } from "zustand/react/shallow";
+import { Button } from "../ui/button";
+import { getUniqueId } from "@/lib/utils";
+import { useCallback } from "react";
+import MessageComponentRow from "./MessageComponentRow";
+
+export default function MessageComponentsSection() {
+  const components = useCurrentMessage(
+    useShallow((state) => state.components.map((e) => e.id))
+  );
+  const addRow = useCurrentMessage((state) => state.addComponentRow);
+  const clearComponents = useCurrentMessage(
+    (state) => state.clearComponentRows
+  );
+
+  const addButtonRow = useCallback(() => {
+    if (components.length >= 5) return;
+    addRow({
+      id: getUniqueId(),
+      type: 1,
+      components: [],
+    });
+  }, [components, addRow]);
+
+  /* const addSelectMenuRow = useCallback(() => {
+    if (components.length >= 5) return;
+    addRow({
+      id: getUniqueId(),
+      type: 1,
+      components: [
+        {
+          id: getUniqueId(),
+          type: 3,
+          options: [],
+        },
+      ],
+    });
+  }, [components, addRow]); */
+
+  return (
+    <CollapsibleSection
+      title="Components"
+      valiationPathPrefix="components"
+      className="space-y-4"
+    >
+      {components.map((id, i) => (
+        <MessageComponentRow key={id} rowIndex={i} rowId={id} />
+      ))}
+      <div className="space-x-3">
+        <Button onClick={addButtonRow}>Add Button Row</Button>
+        <Button onClick={clearComponents} variant="outline">
+          Clear Components
+        </Button>
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/kite-web/src/components/message/MessageControlsButton.tsx
+++ b/kite-web/src/components/message/MessageControlsButton.tsx
@@ -2,7 +2,6 @@ import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { forwardRef, ReactNode } from "react";

--- a/kite-web/src/components/message/MessageEditor.tsx
+++ b/kite-web/src/components/message/MessageEditor.tsx
@@ -3,6 +3,7 @@ import MessageEmbedSection from "./MessageEmbedSection";
 import MessageBody from "./MessageBody";
 import MessageControls from "./MessageControls";
 import MessageValidator from "./MessageValidator";
+import MessageComponentsSection from "./MessageComponentsSection";
 
 export default function MessageEditor() {
   return (
@@ -12,6 +13,7 @@ export default function MessageEditor() {
 
       <MessageAttachmentSection />
       <MessageEmbedSection />
+      <MessageComponentsSection />
 
       <MessageValidator />
     </div>

--- a/kite-web/src/components/message/MessageEmbed.tsx
+++ b/kite-web/src/components/message/MessageEmbed.tsx
@@ -1,5 +1,5 @@
 import { Card } from "@/components/ui/card";
-import CollapsibleSection from "./MessageCollapsibleSection";
+import MessageCollapsibleSection from "./MessageCollapsibleSection";
 import { useCurrentMessage } from "@/lib/message/state";
 import { useShallow } from "zustand/react/shallow";
 import { useMemo } from "react";
@@ -48,7 +48,7 @@ export default function MessageEmbed({
         borderLeftColor: colorHex,
       }}
     >
-      <CollapsibleSection
+      <MessageCollapsibleSection
         title={`Embed ${embedIndex + 1}`}
         size="lg"
         valiationPathPrefix={`embeds.${embedIndex}`}
@@ -89,7 +89,7 @@ export default function MessageEmbed({
         <MessageEmbedImages embedIndex={embedIndex} embedId={embedId} />
         <MessageEmbedFooter embedIndex={embedIndex} embedId={embedId} />
         <MessageEmbedFields embedIndex={embedIndex} embedId={embedId} />
-      </CollapsibleSection>
+      </MessageCollapsibleSection>
     </Card>
   );
 }

--- a/kite-web/src/components/message/MessageEmbedField.tsx
+++ b/kite-web/src/components/message/MessageEmbedField.tsx
@@ -1,6 +1,5 @@
 import { useCurrentMessage } from "@/lib/message/state";
 import { Card } from "@/components/ui/card";
-import CollapsibleSection from "./MessageCollapsibleSection";
 import MessageInput from "./MessageInput";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -9,6 +8,7 @@ import {
   CopyIcon,
   TrashIcon,
 } from "lucide-react";
+import MessageCollapsibleSection from "./MessageCollapsibleSection";
 
 export default function MessageEmbedField({
   embedIndex,
@@ -55,7 +55,7 @@ export default function MessageEmbedField({
 
   return (
     <Card className="p-3">
-      <CollapsibleSection
+      <MessageCollapsibleSection
         title={`Field ${fieldIndex + 1}`}
         size="md"
         valiationPathPrefix={`embeds.${embedIndex}.fields.${fieldIndex}`}
@@ -116,7 +116,7 @@ export default function MessageEmbedField({
           onChange={(v) => setValue(embedIndex, fieldIndex, v)}
           validationPath={`embeds.${embedIndex}.fields.${fieldIndex}.value`}
         />
-      </CollapsibleSection>
+      </MessageCollapsibleSection>
     </Card>
   );
 }

--- a/kite-web/src/components/message/MessageEmbedSection.tsx
+++ b/kite-web/src/components/message/MessageEmbedSection.tsx
@@ -4,7 +4,6 @@ import MessageEmbed from "./MessageEmbed";
 import { useShallow } from "zustand/react/shallow";
 import { getUniqueId } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import AutoAnimate from "../common/AutoAnimate";
 
 export default function MessageEmbedSection() {
   const embeds = useCurrentMessage(
@@ -19,11 +18,9 @@ export default function MessageEmbedSection() {
       valiationPathPrefix="embeds"
       className="space-y-4"
     >
-      <AutoAnimate className="space-y-4">
-        {embeds.map((id, i) => (
-          <MessageEmbed key={id} embedIndex={i} embedId={id} />
-        ))}
-      </AutoAnimate>
+      {embeds.map((id, i) => (
+        <MessageEmbed key={id} embedIndex={i} embedId={id} />
+      ))}
       <div className="space-x-3">
         <Button
           onClick={() =>
@@ -33,10 +30,11 @@ export default function MessageEmbedSection() {
               fields: [],
             })
           }
+          disabled={embeds.length >= 10}
         >
           Add Embed
         </Button>
-        <Button onClick={clearEmbeds} variant="destructive">
+        <Button onClick={clearEmbeds} variant="outline">
           Clear Embeds
         </Button>
       </div>

--- a/kite-web/src/components/message/MessageEmojiPicker.tsx
+++ b/kite-web/src/components/message/MessageEmojiPicker.tsx
@@ -1,0 +1,53 @@
+import EmojiPicker from "@/components/common/EmojiPicker";
+import { Emoji } from "@/lib/message/schema";
+import Twemoji from "../common/Twemoji";
+import { Button } from "../ui/button";
+import { SmileIcon, XIcon } from "lucide-react";
+
+interface Props {
+  emoji: Emoji | undefined;
+  onChange: (emoji: Emoji | undefined) => void;
+}
+
+export default function MessageEmojiPicker({ emoji, onChange }: Props) {
+  function onEmojiSelect(emoji: string) {
+    onChange({ name: emoji, animated: false });
+  }
+
+  return (
+    <div className="flex-none">
+      <div className="mb-2">
+        <div className="text-base text-slate-800 dark:text-slate-200">
+          Emoji
+        </div>
+      </div>
+      <div className="flex">
+        <div className="bg-dark-2 rounded flex">
+          <EmojiPicker onEmojiSelect={onEmojiSelect}>
+            <Button size="icon" variant="outline">
+              {emoji ? (
+                <Twemoji
+                  options={{
+                    className: "h-6 w-6",
+                  }}
+                >
+                  {emoji.name}
+                </Twemoji>
+              ) : (
+                <SmileIcon className="h-6 w-6 text-foreground/80" />
+              )}
+            </Button>
+          </EmojiPicker>
+          {emoji && (
+            <div
+              className="flex items-center cursor-pointer pr-1 text-muted-foreground hover:text-foreground"
+              onClick={() => onChange(undefined)}
+            >
+              <XIcon className="h-5 w-5" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/kite-web/src/components/message/MessageJSONDialog.tsx
+++ b/kite-web/src/components/message/MessageJSONDialog.tsx
@@ -15,7 +15,7 @@ import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
 import { linter, lintGutter } from "@codemirror/lint";
 import { Button } from "../ui/button";
 import { useCurrentMessage } from "@/lib/message/state";
-import { parseMessageWithAction } from "@/lib/message/schemaRestore";
+import { parseMessageData } from "@/lib/message/schemaRestore";
 import { toast } from "sonner";
 import { useHookedTheme } from "@/lib/hooks/theme";
 
@@ -37,7 +37,7 @@ export default function MessageJSONDialog({
 
   const save = useCallback(() => {
     try {
-      const data = parseMessageWithAction(JSON.parse(raw));
+      const data = parseMessageData(JSON.parse(raw));
 
       msg.replace(data);
       setOpen(false);

--- a/kite-web/src/components/message/MessagePreview.tsx
+++ b/kite-web/src/components/message/MessagePreview.tsx
@@ -155,16 +155,16 @@ export default function MessagePreview({
 function MessagePreviewAttachment({ assetId }: { assetId: string }) {
   const asset = useResponseData(useAssetQuery(useAppId(), assetId));
 
-  if (!asset) return null;
-
   const [isImage, isVideo, isAudio] = useMemo(
     () => [
-      asset.content_type.startsWith("image/"),
-      asset.content_type.startsWith("video/"),
-      asset.content_type.startsWith("audio/"),
+      asset?.content_type.startsWith("image/"),
+      asset?.content_type.startsWith("video/"),
+      asset?.content_type.startsWith("audio/"),
     ],
     [asset]
   );
+
+  if (!asset) return null;
 
   if (isImage) {
     return (

--- a/kite-web/src/components/message/MessagePreview.tsx
+++ b/kite-web/src/components/message/MessagePreview.tsx
@@ -3,19 +3,38 @@ import { Message } from "@/lib/message/schema";
 import { colorIntToHex } from "@/tools/common/utils/color";
 
 import {
+  DiscordActionRow,
+  DiscordAttachments,
+  DiscordAudioAttachment,
+  DiscordButton,
   DiscordEmbed,
   DiscordEmbedDescription,
   DiscordEmbedField,
   DiscordEmbedFields,
   DiscordEmbedFooter,
+  DiscordFileAttachment,
+  DiscordImageAttachment,
   DiscordMessage,
   DiscordMessages,
+  DiscordVideoAttachment,
 } from "@skyra/discord-components-react";
 import MessageMarkdown from "./MessageMarkdown";
 import { cn } from "@/lib/utils";
+import { useAssetQuery } from "@/lib/api/queries";
+import { useAppId } from "@/lib/hooks/params";
+import { useResponseData } from "@/lib/hooks/api";
+import { useMemo } from "react";
 
 const defaultUsername = "Captain Hook";
 const defaultAvatarUrl = "orange";
+
+const buttonStyles = {
+  1: "primary",
+  2: "secondary",
+  3: "success",
+  4: "destructive",
+  5: "secondary",
+} as const;
 
 export default function MessagePreview({
   msg,
@@ -37,63 +56,155 @@ export default function MessagePreview({
       >
         <MessageMarkdown>{msg.content}</MessageMarkdown>
 
-        {msg.embeds &&
-          msg.embeds.map((embed) => {
-            const hexColor = embed.color
-              ? colorIntToHex(embed.color)
-              : "#1f2225";
-            let timestamp = "";
-            if (embed.timestamp) {
-              const date = parseISO(embed.timestamp);
-              if (!isNaN(date.getTime())) {
-                timestamp = format(date, "dd/MM/yyyy");
-              }
+        {msg.embeds.map((embed) => {
+          const hexColor = embed.color ? colorIntToHex(embed.color) : "#1f2225";
+          let timestamp = "";
+          if (embed.timestamp) {
+            const date = parseISO(embed.timestamp);
+            if (!isNaN(date.getTime())) {
+              timestamp = format(date, "dd/MM/yyyy");
             }
-            return (
-              <DiscordEmbed
-                key={embed.id}
-                color={hexColor}
-                authorName={embed.author?.name}
-                authorImage={embed.author?.icon_url}
-                authorUrl={embed.author?.url}
-                provider={embed.provider?.name}
-                embedTitle={embed.title}
-                url={embed.url}
-                image={embed.image?.url}
-                thumbnail={embed.thumbnail?.url}
-                slot="embeds"
-              >
-                {!!embed.description && (
-                  <DiscordEmbedDescription slot="description">
-                    {embed.description}
-                  </DiscordEmbedDescription>
+          }
+          return (
+            <DiscordEmbed
+              key={embed.id}
+              color={hexColor}
+              authorName={embed.author?.name}
+              authorImage={embed.author?.icon_url}
+              authorUrl={embed.author?.url}
+              provider={embed.provider?.name}
+              embedTitle={embed.title}
+              url={embed.url}
+              image={embed.image?.url}
+              thumbnail={embed.thumbnail?.url}
+              slot="embeds"
+            >
+              {!!embed.description && (
+                <DiscordEmbedDescription slot="description">
+                  {embed.description}
+                </DiscordEmbedDescription>
+              )}
+              {!!embed.fields?.length && (
+                <DiscordEmbedFields slot="fields">
+                  {embed.fields.map((field) => (
+                    <DiscordEmbedField
+                      key={field.id}
+                      fieldTitle={field.name}
+                      inline={field.inline}
+                    >
+                      {field.value}
+                    </DiscordEmbedField>
+                  ))}
+                </DiscordEmbedFields>
+              )}
+              {(embed.footer?.text || timestamp) && (
+                <DiscordEmbedFooter
+                  slot="footer"
+                  footerImage={embed.footer?.icon_url}
+                  timestamp={timestamp}
+                >
+                  {embed.footer?.text}
+                </DiscordEmbedFooter>
+              )}
+            </DiscordEmbed>
+          );
+        })}
+
+        {msg.attachments.length != 0 && (
+          <DiscordAttachments slot="attachments">
+            {msg.attachments.map((attachment) => (
+              <MessagePreviewAttachment
+                key={attachment.asset_id}
+                assetId={attachment.asset_id}
+              />
+            ))}
+          </DiscordAttachments>
+        )}
+
+        {msg.components.length != 0 && (
+          <DiscordAttachments slot="components">
+            {msg.components.map((row) => (
+              <DiscordActionRow key={row.id}>
+                {row.components.map((comp) =>
+                  comp.type === 2 ? (
+                    <DiscordButton
+                      key={comp.id}
+                      type={buttonStyles[comp.style]}
+                      url={comp.style === 5 ? comp.url : undefined}
+                      emoji={
+                        comp.emoji?.name
+                          ? getTwemojiUrl(comp.emoji.name)
+                          : undefined
+                      }
+                      emojiName={comp.emoji?.name}
+                      disabled={comp.disabled}
+                    >
+                      {comp.label}
+                    </DiscordButton>
+                  ) : null
                 )}
-                {!!embed.fields?.length && (
-                  <DiscordEmbedFields slot="fields">
-                    {embed.fields.map((field) => (
-                      <DiscordEmbedField
-                        key={field.id}
-                        fieldTitle={field.name}
-                        inline={field.inline}
-                      >
-                        {field.value}
-                      </DiscordEmbedField>
-                    ))}
-                  </DiscordEmbedFields>
-                )}
-                {(embed.footer?.text || timestamp) && (
-                  <DiscordEmbedFooter
-                    slot="footer"
-                    footerImage={embed.footer?.icon_url}
-                    timestamp={timestamp}
-                  >
-                    {embed.footer?.text}
-                  </DiscordEmbedFooter>
-                )}
-              </DiscordEmbed>
-            );
-          })}
+              </DiscordActionRow>
+            ))}
+          </DiscordAttachments>
+        )}
       </DiscordMessage>
     </DiscordMessages>
   );
+}
+
+function MessagePreviewAttachment({ assetId }: { assetId: string }) {
+  const asset = useResponseData(useAssetQuery(useAppId(), assetId));
+
+  if (!asset) return null;
+
+  const [isImage, isVideo, isAudio] = useMemo(
+    () => [
+      asset.content_type.startsWith("image/"),
+      asset.content_type.startsWith("video/"),
+      asset.content_type.startsWith("audio/"),
+    ],
+    [asset]
+  );
+
+  if (isImage) {
+    return (
+      <DiscordImageAttachment
+        url={asset.url}
+        alt={asset.name}
+        height={256}
+        width={256}
+      />
+    );
+  } else if (isVideo) {
+    return <DiscordVideoAttachment href={asset.url} />;
+  } else if (isAudio) {
+    return (
+      <DiscordAudioAttachment
+        name={asset.name}
+        href={asset.url}
+        bytes={asset.content_size / 1_000_000}
+        bytesUnit="MB"
+      />
+    );
+  } else {
+    return (
+      <DiscordFileAttachment
+        name={asset.name}
+        bytes={asset.content_size / 1_000_000}
+        bytesUnit="MB"
+        href={asset.url}
+        target="_blank"
+        type={asset.content_type}
+      />
+    );
+  }
+}
+
+function getTwemojiUrl(emoji: string) {
+  const baseUrl =
+    "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/";
+
+  const codePoints = emoji.codePointAt(0)?.toString(16);
+  if (!codePoints) return "";
+  return `${baseUrl}${codePoints}.png`;
 }

--- a/kite-web/src/lib/flow/components.ts
+++ b/kite-web/src/lib/flow/components.ts
@@ -19,6 +19,7 @@ import FlowNodeControlSleep from "@/components/flow/FlowNodeControlSleep";
 export const nodeTypes = {
   entry_command: FlowNodeEntryCommand,
   entry_event: FlowNodeEntryEvent,
+  entry_component_button: FlowNodeEntryEvent,
 
   option_command_argument: FlowNodeOptionCommandArgument,
   option_command_permissions: FlowNodeOptionBase,

--- a/kite-web/src/lib/flow/data.ts
+++ b/kite-web/src/lib/flow/data.ts
@@ -74,6 +74,8 @@ export const nodeEntryEventDataSchema = nodeBaseDataSchema.extend({
   event_type: z.string(),
 });
 
+export const nodeEntryComponentButtonDataSchema = nodeBaseDataSchema.extend({});
+
 export const nodeActionResponseCreateDataSchema = nodeBaseDataSchema
   .extend({
     message_data: z

--- a/kite-web/src/lib/flow/nodes.ts
+++ b/kite-web/src/lib/flow/nodes.ts
@@ -19,6 +19,7 @@ import {
   nodeControlSleepDataSchema,
   NodeData,
   nodeEntryCommandDataSchema,
+  nodeEntryComponentButtonDataSchema,
   nodeEntryEventDataSchema,
   nodeOptionCommandArgumentDataSchema,
   nodeOptionCommandContextsSchema,
@@ -56,6 +57,7 @@ import {
   XCircleIcon,
   TimerIcon,
   UserRoundCheckIcon,
+  MousePointerClickIcon,
 } from "lucide-react";
 
 export const primaryColor = "#3B82F6";
@@ -93,9 +95,19 @@ export const nodeTypes: Record<string, NodeValues> = {
     icon: SatelliteDishIcon,
     defaultTitle: "Listen for Event",
     defaultDescription:
-      "Listens for an event to trigger the flow. Drop different actions and options here!",
+      "Listens for an event to trigger the flow. Drop different actions here!",
     dataSchema: nodeEntryEventDataSchema,
     dataFields: ["event_type"],
+    fixed: true,
+  },
+  entry_component_button: {
+    color: entryColor,
+    icon: MousePointerClickIcon,
+    defaultTitle: "Button",
+    defaultDescription:
+      "This gets triggered when a user clicks the button. Drop different actions here!",
+    dataSchema: nodeEntryComponentButtonDataSchema,
+    dataFields: [],
     fixed: true,
   },
   action_response_create: {

--- a/kite-web/src/lib/message/flowStore.ts
+++ b/kite-web/src/lib/message/flowStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { FlowData } from "../flow/data";
+import { immer } from "zustand/middleware/immer";
+
+export interface FlowStore {
+  flowSources: Record<string, FlowData>;
+  replaceAll(data: Record<string, FlowData>): void;
+  replaceFlow(id: string, data: FlowData): void;
+  getFlow(id: string): FlowData | undefined;
+}
+
+export const createFlowStore = (initialData?: Record<string, FlowData>) => {
+  return create<FlowStore>()(
+    immer((set, get) => ({
+      flowSources: initialData || {},
+
+      replaceAll: (data) => set({ flowSources: data }),
+      replaceFlow: (id: string, data: FlowData) =>
+        set((state) => {
+          state.flowSources[id] = data;
+        }),
+      getFlow: (id: string) => get().flowSources[id],
+    }))
+  );
+};

--- a/kite-web/src/lib/message/messageStore.ts
+++ b/kite-web/src/lib/message/messageStore.ts
@@ -1,5 +1,4 @@
-import { create, useStore } from "zustand";
-import { persist } from "zustand/middleware";
+import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import {
   MessageComponentButtonStyle,
@@ -547,21 +546,8 @@ export const createMessageStore = (initial?: Message) => {
                 id: getUniqueId(),
                 type: 1,
                 components: row.components.map((comp) => {
-                  if (comp.type === 2) {
-                    const actionId = getUniqueId().toString();
-                    return { ...comp, action_set_id: actionId };
-                  } else {
-                    return {
-                      ...comp,
-                      options: comp.options.map((option) => {
-                        const actionId = getUniqueId().toString();
-                        return {
-                          ...option,
-                          action_set_id: actionId,
-                        };
-                      }),
-                    };
-                  }
+                  const flowSourceId = getUniqueId().toString();
+                  return { ...comp, flow_source_id: flowSourceId };
                 }),
               };
 
@@ -645,7 +631,7 @@ export const createMessageStore = (initial?: Message) => {
               row.components.splice(j + 1, 0, {
                 ...button,
                 id: getUniqueId(),
-                action_set_id: actionId,
+                flow_source_id: actionId,
               });
             }),
           setButtonStyle: (
@@ -835,11 +821,9 @@ export const createMessageStore = (initial?: Message) => {
                 return;
               }
 
-              const actionId = getUniqueId().toString();
               selectMenu.options.splice(k + 1, 0, {
                 ...option,
                 id: getUniqueId(),
-                action_set_id: actionId,
               });
             }),
           deleteSelectMenuOption: (i: number, j: number, k: number) =>

--- a/kite-web/src/lib/message/messageStore.ts
+++ b/kite-web/src/lib/message/messageStore.ts
@@ -14,7 +14,7 @@ import {
   MessageAttachment,
 } from "./schema";
 import { getUniqueId } from "@/lib/utils";
-import { TemporalState, temporal } from "zundo";
+import { temporal } from "zundo";
 import debounce from "just-debounce-it";
 
 export interface MessageStore extends Message {

--- a/kite-web/src/lib/message/schema.ts
+++ b/kite-web/src/lib/message/schema.ts
@@ -235,7 +235,7 @@ export const buttonSchema = z
     type: z.literal(2),
     style: z.literal(1).or(z.literal(2)).or(z.literal(3)).or(z.literal(4)),
     label: z.string(),
-    emoji: z.optional(z.nullable(emojiSchema)),
+    emoji: z.optional(emojiSchema),
     disabled: z.optional(z.boolean()),
     action_set_id: z.string().default(() => getUniqueId().toString()),
   })
@@ -245,7 +245,7 @@ export const buttonSchema = z
       type: z.literal(2),
       style: z.literal(5),
       label: z.string(),
-      emoji: z.optional(z.nullable(emojiSchema)),
+      emoji: z.optional(emojiSchema),
       url: z.string().refine(...urlRefinement),
       disabled: z.optional(z.boolean()),
       action_set_id: z.string().default(() => getUniqueId().toString()),
@@ -267,7 +267,7 @@ export const selectMenuOptionSchema = z.object({
   id: uniqueIdSchema.default(() => getUniqueId()),
   label: z.string().min(1).max(100),
   description: z.optional(z.string().min(1).max(100)),
-  emoji: z.optional(z.nullable(emojiSchema)),
+  emoji: z.optional(emojiSchema),
   action_set_id: z.string().default(() => getUniqueId().toString()),
 });
 

--- a/kite-web/src/lib/message/schema.ts
+++ b/kite-web/src/lib/message/schema.ts
@@ -237,7 +237,7 @@ export const buttonSchema = z
     label: z.string(),
     emoji: z.optional(emojiSchema),
     disabled: z.optional(z.boolean()),
-    action_set_id: z.string().default(() => getUniqueId().toString()),
+    flow_source_id: z.string().default(() => getUniqueId().toString()),
   })
   .or(
     z.object({
@@ -248,7 +248,7 @@ export const buttonSchema = z
       emoji: z.optional(emojiSchema),
       url: z.string().refine(...urlRefinement),
       disabled: z.optional(z.boolean()),
-      action_set_id: z.string().default(() => getUniqueId().toString()),
+      flow_source_id: z.string().default(() => getUniqueId().toString()),
     })
   )
   .superRefine((data, ctx) => {
@@ -268,7 +268,6 @@ export const selectMenuOptionSchema = z.object({
   label: z.string().min(1).max(100),
   description: z.optional(z.string().min(1).max(100)),
   emoji: z.optional(emojiSchema),
-  action_set_id: z.string().default(() => getUniqueId().toString()),
 });
 
 export type MessageComponentSelectMenuOption = z.infer<
@@ -281,6 +280,7 @@ export const selectMenuSchema = z.object({
   placeholder: z.optional(z.string().max(150)),
   disabled: z.optional(z.boolean()),
   options: z.array(selectMenuOptionSchema).min(1).max(25),
+  flow_source_id: z.string().default(() => getUniqueId().toString()),
 });
 
 export type MessageComponentSelectMenu = z.infer<typeof selectMenuSchema>;

--- a/kite-web/src/lib/message/schemaRestore.ts
+++ b/kite-web/src/lib/message/schemaRestore.ts
@@ -245,7 +245,7 @@ export const buttonSchema = z
     label: z.preprocess((d) => d ?? undefined, z.string().default("")),
     emoji: z.preprocess((d) => d ?? undefined, z.optional(emojiSchema)),
     disabled: z.preprocess((d) => d ?? undefined, z.optional(z.boolean())),
-    action_set_id: z.preprocess(
+    flow_source_id: z.preprocess(
       (d) => d ?? undefined,
       z.string().default(() => getUniqueId().toString())
     ),
@@ -259,7 +259,7 @@ export const buttonSchema = z
       emoji: z.preprocess((d) => d ?? undefined, z.optional(emojiSchema)),
       url: z.preprocess((d) => d ?? undefined, z.string().default("")),
       disabled: z.preprocess((d) => d ?? undefined, z.optional(z.boolean())),
-      action_set_id: z.string().default(() => getUniqueId().toString()),
+      flow_source_id: z.string().default(() => getUniqueId().toString()),
     })
   );
 
@@ -270,10 +270,6 @@ export const selectMenuOptionSchema = z.object({
   label: z.preprocess((d) => d ?? undefined, z.string().default("")),
   description: z.preprocess((d) => d || undefined, z.optional(z.string())),
   emoji: z.preprocess((d) => d ?? undefined, z.optional(emojiSchema)),
-  action_set_id: z.preprocess(
-    (d) => d ?? undefined,
-    z.string().default(() => getUniqueId().toString())
-  ),
 });
 
 export type MessageComponentSelectMenuOption = z.infer<
@@ -289,6 +285,7 @@ export const selectMenuSchema = z.object({
     (d) => d ?? undefined,
     z.array(selectMenuOptionSchema).default([])
   ),
+  flow_source_id: z.string().default(() => getUniqueId().toString()),
 });
 
 export type MessageComponentSelectMenu = z.infer<typeof selectMenuSchema>;
@@ -425,37 +422,11 @@ export const messageSchema = z.object({
     z.array(actionRowSchema).default([])
   ),
   thread_name: messageThreadNameSchema,
-  actions: z.preprocess(
-    (d) => d ?? undefined,
-    z.record(z.string(), messageActionSetSchema).default({})
-  ),
 });
 
 export type Message = z.infer<typeof messageSchema>;
 
-export function parseMessageWithAction(raw: any) {
+export function parseMessageData(raw: any) {
   const parsedData = messageSchema.parse(raw);
-
-  // create messing action sets
-  for (const row of parsedData.components) {
-    for (const comp of row.components) {
-      if (comp.type === 2) {
-        if (!parsedData.actions[comp.action_set_id]) {
-          parsedData.actions[comp.action_set_id] = {
-            actions: [],
-          };
-        }
-      } else {
-        for (const option of comp.options) {
-          if (!parsedData.actions[option.action_set_id]) {
-            parsedData.actions[option.action_set_id] = {
-              actions: [],
-            };
-          }
-        }
-      }
-    }
-  }
-
   return parsedData;
 }

--- a/kite-web/src/lib/message/schemaRestore.ts
+++ b/kite-web/src/lib/message/schemaRestore.ts
@@ -243,7 +243,7 @@ export const buttonSchema = z
     type: z.literal(2),
     style: z.literal(1).or(z.literal(2)).or(z.literal(3)).or(z.literal(4)),
     label: z.preprocess((d) => d ?? undefined, z.string().default("")),
-    emoji: z.optional(z.nullable(emojiSchema)),
+    emoji: z.preprocess((d) => d ?? undefined, z.optional(emojiSchema)),
     disabled: z.preprocess((d) => d ?? undefined, z.optional(z.boolean())),
     action_set_id: z.preprocess(
       (d) => d ?? undefined,
@@ -256,7 +256,7 @@ export const buttonSchema = z
       type: z.literal(2),
       style: z.literal(5),
       label: z.preprocess((d) => d ?? undefined, z.string().default("")),
-      emoji: z.optional(z.nullable(emojiSchema)),
+      emoji: z.preprocess((d) => d ?? undefined, z.optional(emojiSchema)),
       url: z.preprocess((d) => d ?? undefined, z.string().default("")),
       disabled: z.preprocess((d) => d ?? undefined, z.optional(z.boolean())),
       action_set_id: z.string().default(() => getUniqueId().toString()),

--- a/kite-web/src/lib/message/state.tsx
+++ b/kite-web/src/lib/message/state.tsx
@@ -6,10 +6,12 @@ import {
   createValidationErrorStore,
   ValidationErrorStore,
 } from "./validationStore";
+import { createFlowStore, FlowStore } from "./flowStore";
 
 type ContextValue = {
   messageStore: ReturnType<typeof createMessageStore>;
   validationStore: ReturnType<typeof createValidationErrorStore>;
+  flowStore: ReturnType<typeof createFlowStore>;
 };
 
 const CurrentMessageStoreContext = createContext<ContextValue | null>(null);
@@ -21,11 +23,13 @@ export function CurrentMessageStoreProvider({
 }) {
   const [messageStore] = useState(() => createMessageStore());
   const [validationStore] = useState(() => createValidationErrorStore());
+  const [flowStore] = useState(() => createFlowStore());
 
   const value = useMemo(
     () => ({
       messageStore,
       validationStore,
+      flowStore,
     }),
     [messageStore, validationStore]
   );
@@ -75,5 +79,21 @@ export function useValidationErrors<T>(
   selector: (store: ValidationErrorStore) => T
 ): T {
   const store = useValidationErrorStore();
+  return useStore(store, selector);
+}
+
+export function useCurrentFlowStore() {
+  const value = useContext(CurrentMessageStoreContext);
+  if (!value) {
+    throw new Error(
+      "useCurrentFlowStore must be used within a CurrentMessageStoreProvider provider"
+    );
+  }
+
+  return value.flowStore;
+}
+
+export function useCurrentFlow<T>(selector: (store: FlowStore) => T): T {
+  const store = useCurrentFlowStore();
   return useStore(store, selector);
 }

--- a/kite-web/src/lib/message/state.tsx
+++ b/kite-web/src/lib/message/state.tsx
@@ -31,7 +31,7 @@ export function CurrentMessageStoreProvider({
       validationStore,
       flowStore,
     }),
-    [messageStore, validationStore]
+    [messageStore, validationStore, flowStore]
   );
 
   return (

--- a/kite-web/src/lib/types/message.gen.ts
+++ b/kite-web/src/lib/types/message.gen.ts
@@ -8,11 +8,13 @@ export interface MessageData {
   flags?: number /* int */;
   attachments?: MessageAttachment[];
   embeds?: EmbedData[];
+  components?: ComponentRowData[];
 }
 export interface MessageAttachment {
   asset_id?: string;
 }
 export interface EmbedData {
+  id?: number /* int */;
   title?: string;
   description?: string;
   url?: string;
@@ -40,7 +42,45 @@ export interface EmbedAuthorData {
   icon_url?: string;
 }
 export interface EmbedFieldData {
+  id?: number /* int */;
   name?: string;
   value?: string;
   inline?: boolean;
+}
+export interface ComponentRowData {
+  id?: number /* int */;
+  components?: ComponentData[];
+}
+export interface ComponentData {
+  id?: number /* int */;
+  type?: number /* int */;
+  disabled?: boolean;
+  /**
+   * Button
+   */
+  style?: number /* int */;
+  label?: string;
+  emoji?: ComponentEmojiData;
+  url?: string;
+  /**
+   * Select Menu
+   */
+  placeholder?: string;
+  min_values?: number /* int */;
+  max_values?: number /* int */;
+  options?: ComponentSelectOptionData[];
+  flow_source_id?: string;
+}
+export interface ComponentSelectOptionData {
+  id?: number /* int */;
+  label?: string;
+  description?: string;
+  emoji?: ComponentEmojiData;
+  default?: boolean;
+  flow_source_id?: string;
+}
+export interface ComponentEmojiData {
+  name?: string;
+  id?: string;
+  animated?: boolean;
 }

--- a/kite-web/src/pages/apps/[appId]/commands/[cmdId]/index.tsx
+++ b/kite-web/src/pages/apps/[appId]/commands/[cmdId]/index.tsx
@@ -1,4 +1,4 @@
-import Flow from "@/components/flow/Flow";
+import FlowPage from "@/components/flow/FlowPage";
 import { useCommandUpdateMutation } from "@/lib/api/mutations";
 import { FlowData } from "@/lib/flow/data";
 import { useCommand } from "@/lib/hooks/api";
@@ -106,7 +106,7 @@ export default function AppCommandPage() {
         <title>Manage Command | Kite</title>
       </Head>
       {cmd && (
-        <Flow
+        <FlowPage
           flowData={cmd.flow_source}
           hasUnsavedChanges={hasUnsavedChanges}
           onChange={onChange}

--- a/kite-web/src/pages/apps/[appId]/messages/[messageId]/index.tsx
+++ b/kite-web/src/pages/apps/[appId]/messages/[messageId]/index.tsx
@@ -79,7 +79,7 @@ function AppMessagePageInner() {
     } catch (e) {
       toast.error(`Failed to parse message data: ${e}`);
     }
-  }, [message, messageStore]);
+  }, [message, messageStore, flowStore]);
 
   const updateMutation = useMessageUpdateMutation(useAppId(), useMessageId());
 
@@ -120,6 +120,7 @@ function AppMessagePageInner() {
     setIsSaving,
     setHasUnsavedChanges,
     messageStore,
+    flowStore,
   ]);
 
   const exit = useCallback(() => {

--- a/kite-web/src/pages/apps/[appId]/messages/[messageId]/index.tsx
+++ b/kite-web/src/pages/apps/[appId]/messages/[messageId]/index.tsx
@@ -8,12 +8,10 @@ import { useMessageUpdateMutation } from "@/lib/api/mutations";
 import { useMessage } from "@/lib/hooks/api";
 import { useBeforePageExit } from "@/lib/hooks/exit";
 import { useAppId, useMessageId } from "@/lib/hooks/params";
-import {
-  messageSchema,
-  parseMessageWithAction,
-} from "@/lib/message/schemaRestore";
+import { messageSchema, parseMessageData } from "@/lib/message/schemaRestore";
 import {
   CurrentMessageStoreProvider,
+  useCurrentFlowStore,
   useCurrentMessage,
   useCurrentMessageStore,
 } from "@/lib/message/state";
@@ -43,29 +41,40 @@ function AppMessagePageInner() {
   });
 
   const messageStore = useCurrentMessageStore();
+  const flowStore = useCurrentFlowStore();
 
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = messageStore.subscribe(() => {
+    const unsubscribeMessage = messageStore.subscribe(() => {
       if (!ignoreChange.current) {
         setHasUnsavedChanges(true);
       }
     });
 
-    return unsubscribe;
-  }, [ignoreChange, messageStore]);
+    const unsubscribeFlow = flowStore.subscribe(() => {
+      if (!ignoreChange.current) {
+        setHasUnsavedChanges(true);
+      }
+    });
+
+    return () => {
+      unsubscribeMessage();
+      unsubscribeFlow();
+    };
+  }, [ignoreChange, messageStore, flowStore]);
 
   useEffect(() => {
     if (!message) return;
 
     try {
-      const data = parseMessageWithAction(message.data);
+      const data = parseMessageData(message.data);
 
       ignoreChange.current = true;
       messageStore.getState().replace(data);
       messageStore.temporal.getState().clear();
+      flowStore.getState().replaceAll(message.flow_sources);
       ignoreChange.current = false;
     } catch (e) {
       toast.error(`Failed to parse message data: ${e}`);
@@ -80,13 +89,14 @@ function AppMessagePageInner() {
     setIsSaving(true);
 
     const data = messageStore.getState();
+    const flowSources = flowStore.getState().flowSources;
 
     updateMutation.mutate(
       {
         name: message.name,
         description: message.description,
         data: data,
-        flow_sources: {},
+        flow_sources: flowSources,
       },
       {
         onSuccess(res) {

--- a/kite-web/src/tools/common/components/BaseInput.tsx
+++ b/kite-web/src/tools/common/components/BaseInput.tsx
@@ -13,7 +13,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { DatePicker } from "./DatePicker";
-import { CircleAlertIcon, UploadIcon } from "lucide-react";
+import { CircleAlertIcon } from "lucide-react";
 import ImageUploadButton from "./ImageUploadButton";
 
 export type BaseInputProps = {
@@ -96,13 +96,12 @@ export default function BaseInput(props: BaseInputProps) {
             maxRows={15}
           />
         ) : type === "select" ? (
-          <Select>
+          <Select value={value} onValueChange={onChange}>
             <SelectTrigger>
               <SelectValue placeholder={props.placeholder} />
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectLabel>Fruits</SelectLabel>
                 {props.options.map((option) => (
                   <SelectItem key={option.value} value={option.value}>
                     {option.label}

--- a/kite-web/src/tools/common/components/ImageUploadButton.tsx
+++ b/kite-web/src/tools/common/components/ImageUploadButton.tsx
@@ -36,7 +36,7 @@ export default function ImageUploadButton({
         },
       });
     },
-    [inputRef, createMutation, onImageUploaded]
+    [createMutation, onImageUploaded]
   );
 
   return (
@@ -44,6 +44,7 @@ export default function ImageUploadButton({
       size="icon"
       variant="outline"
       onClick={() => inputRef.current?.click()}
+      disabled={!!inputRef.current?.value}
     >
       <input
         type="file"

--- a/kite-web/tailwind.config.ts
+++ b/kite-web/tailwind.config.ts
@@ -68,10 +68,25 @@ const config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        shake: {
+          "10%, 90%": {
+            transform: "translate3d(-1px, 0, 0)",
+          },
+          "20%, 80%": {
+            transform: "translate3d(2px, 0, 0)",
+          },
+          "30%, 50%, 70%": {
+            transform: "translate3d(-4px, 0, 0)",
+          },
+          "40%, 60%": {
+            transform: "translate3d(4px, 0, 0)",
+          },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        shake: "shake 0.82s cubic-bezier(.36,.07,.19,.97) both",
       },
       fontFamily: {
         sans: ["var(--font-sans)", ...fontFamily.sans],


### PR DESCRIPTION
This PR adds support for interactive components in message templates. Right now only buttons are supported, but support for select menus can be added later on easily.

- [x] Implement frontend for managing components
- [x] Implement frontend for editing the flow for components
- [x] Implement backend to send components
- [x] Implement backend to handle interactions on components and execute their flows
- [x] Support interactive components on responses & messages created in flows

![Bildschirmfoto 2024-09-23 um 13 57 04](https://github.com/user-attachments/assets/713037c1-016b-457a-b2a5-1dbe3efd922d)