### PR TITLE
docs: remove or deprecate discriminator from interaction/event user schema

### DIFF
--- a/kite-docs/docs/reference/expressions.md
+++ b/kite-docs/docs/reference/expressions.md
@@ -31,7 +31,6 @@ interaction: # For command and button interactions
   user:
     id: string
     username: string
-    discriminator: string
     display_name: string
     avatar_url: string
     banner_url: string
@@ -47,7 +46,6 @@ event: # For event listeners
   user:
     id: string
     username: string
-    discriminator: string
     display_name: string
     avatar_url: string
     banner_url: string


### PR DESCRIPTION
In commit e073cff, the "User Discriminator" placeholder was removed from 
FlowPlaceholderExplorer. This updates the documentation accordingly 
to reflect that `user.discriminator` is no longer available and deprecated
I'm not sure tho if this is correct