### PR TITLE
Event Filters

### DIFF
--- a/kite-service/internal/core/engine/data.go
+++ b/kite-service/internal/core/engine/data.go
@@ -14,6 +14,10 @@ func (d *InteractionData) Interaction() *discord.InteractionEvent {
 	return d.interaction
 }
 
+func (d *InteractionData) UserID() discord.UserID {
+	return d.interaction.SenderID()
+}
+
 func (d *InteractionData) GuildID() discord.GuildID {
 	return d.interaction.GuildID
 }
@@ -42,6 +46,22 @@ type EventData struct {
 
 func (d *EventData) Interaction() *discord.InteractionEvent {
 	return nil
+}
+
+func (d *EventData) UserID() discord.UserID {
+	switch data := d.event.(type) {
+	case *gateway.MessageCreateEvent:
+		return data.Author.ID
+	case *gateway.MessageUpdateEvent:
+		return data.Author.ID
+	case *gateway.GuildMemberAddEvent:
+		return data.User.ID
+	case *gateway.GuildMemberRemoveEvent:
+		return data.User.ID
+	case *gateway.GuildMemberUpdateEvent:
+		return data.User.ID
+	}
+	return 0
 }
 
 func (d *EventData) GuildID() discord.GuildID {

--- a/kite-service/internal/core/engine/helpers.go
+++ b/kite-service/internal/core/engine/helpers.go
@@ -141,7 +141,22 @@ func (s Env) executeFlowEvent(
 	fCtx := s.flowContext(ctx, appID, session, event, links, state)
 	defer fCtx.Cancel()
 
-	err := node.Execute(fCtx)
+	shouldExecute, err := node.FilterEvents(fCtx)
+	if err != nil {
+		s.createLogEntry(
+			appID,
+			model.LogLevelError,
+			fmt.Sprintf("Failed to filter events: %v", err),
+			links,
+		)
+		return
+	}
+
+	if !shouldExecute {
+		return
+	}
+
+	err = node.Execute(fCtx)
 	if err != nil {
 		s.createLogEntry(
 			appID,

--- a/kite-service/pkg/flow/context.go
+++ b/kite-service/pkg/flow/context.go
@@ -66,6 +66,7 @@ type FlowContextData interface {
 	MessageComponentData() discord.ComponentInteraction
 	Interaction() *discord.InteractionEvent
 	Event() ws.Event
+	UserID() discord.UserID
 	GuildID() discord.GuildID
 	ChannelID() discord.ChannelID
 }

--- a/kite-service/pkg/flow/data.go
+++ b/kite-service/pkg/flow/data.go
@@ -219,10 +219,10 @@ type FlowNodeData struct {
 	Expression string `json:"expression,omitempty"`
 
 	// Condition
-	ConditionBaseValue     string            `json:"condition_base_value,omitempty"`
-	ConditionAllowMultiple bool              `json:"condition_allow_multiple,omitempty"`
-	ConditionItemMode      ConditionItemType `json:"condition_item_mode,omitempty"`
-	ConditionItemValue     string            `json:"condition_item_value,omitempty"`
+	ConditionBaseValue     string         `json:"condition_base_value,omitempty"`
+	ConditionAllowMultiple bool           `json:"condition_allow_multiple,omitempty"`
+	ConditionItemMode      ComparsionMode `json:"condition_item_mode,omitempty"`
+	ConditionItemValue     string         `json:"condition_item_value,omitempty"`
 	// Loop
 	LoopCount string `json:"loop_count,omitempty"`
 	// Sleep
@@ -279,22 +279,24 @@ func (d FlowNodeData) Validate(nodeType FlowNodeType) error {
 	)
 }
 
-type ConditionItemType string
+type ComparsionMode string
 
 const (
-	ConditionItemModeEqual              ConditionItemType = "equal"
-	ConditionItemModeNotEqual           ConditionItemType = "not_equal"
-	ConditionItemModeGreaterThan        ConditionItemType = "greater_than"
-	ConditionItemModeGreaterThanOrEqual ConditionItemType = "greater_than_or_equal"
-	ConditionItemModeLessThan           ConditionItemType = "less_than"
-	ConditionItemModeLessThanOrEqual    ConditionItemType = "less_than_or_equal"
-	ConditionItemModeContains           ConditionItemType = "contains"
+	ComparsionModeEqual              ComparsionMode = "equal"
+	ComparsionModeNotEqual           ComparsionMode = "not_equal"
+	ComparsionModeGreaterThan        ComparsionMode = "greater_than"
+	ComparsionModeGreaterThanOrEqual ComparsionMode = "greater_than_or_equal"
+	ComparsionModeLessThan           ComparsionMode = "less_than"
+	ComparsionModeLessThanOrEqual    ComparsionMode = "less_than_or_equal"
+	ComparsionModeContains           ComparsionMode = "contains"
+	ComparsionModeStartsWith         ComparsionMode = "starts_with"
+	ComparsionModeEndsWith           ComparsionMode = "ends_with"
 
 	// User condition
-	ConditionItemModeHasRole          ConditionItemType = "has_role"
-	ConditionItemModeNotHasRole       ConditionItemType = "not_has_role"
-	ConditionItemModeHasPermission    ConditionItemType = "has_permission"
-	ConditionItemModeNotHasPermission ConditionItemType = "not_has_permission"
+	ComparsionModeHasRole          ComparsionMode = "has_role"
+	ComparsionModeNotHasRole       ComparsionMode = "not_has_role"
+	ComparsionModeHasPermission    ComparsionMode = "has_permission"
+	ComparsionModeNotHasPermission ComparsionMode = "not_has_permission"
 )
 
 type CommandArgumentType string

--- a/kite-service/pkg/flow/data.go
+++ b/kite-service/pkg/flow/data.go
@@ -208,8 +208,9 @@ type FlowNodeData struct {
 	EventType string `json:"event_type,omitempty"`
 
 	// Event Filter
-	EventFilterTarget     EventFilterTarget `json:"event_filter_target,omitempty"`
-	EventFilterExpression string            `json:"event_filter_expression,omitempty"`
+	EventFilterTarget EventFilterTarget `json:"event_filter_target,omitempty"`
+	EventFilterMode   ComparsionMode    `json:"event_filter_mode,omitempty"`
+	EventFilterValue  string            `json:"event_filter_value,omitempty"`
 
 	// Log
 	LogLevel   provider.LogLevel `json:"log_level,omitempty"`
@@ -332,6 +333,9 @@ type EventFilterTarget string
 
 const (
 	EventFilterTypeMessageContent EventFilterTarget = "message_content"
+	EventFilterTypeUserID         EventFilterTarget = "user_id"
+	EventFilterTypeGuildID        EventFilterTarget = "guild_id"
+	EventFilterTypeChannelID      EventFilterTarget = "channel_id"
 )
 
 type RobloxLookupType string

--- a/kite-service/pkg/flow/execute.go
+++ b/kite-service/pkg/flow/execute.go
@@ -1401,20 +1401,24 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 
 		var conditionMet bool
 		switch n.Data.ConditionItemMode {
-		case ConditionItemModeEqual:
+		case ComparsionModeEqual:
 			conditionMet = baseValue.Equals(&itemValue)
-		case ConditionItemModeNotEqual:
+		case ComparsionModeNotEqual:
 			conditionMet = baseValue.Equals(&itemValue)
-		case ConditionItemModeGreaterThan:
+		case ComparsionModeGreaterThan:
 			conditionMet = baseValue.GreaterThan(&itemValue)
-		case ConditionItemModeGreaterThanOrEqual:
+		case ComparsionModeGreaterThanOrEqual:
 			conditionMet = baseValue.GreaterThanOrEqual(&itemValue)
-		case ConditionItemModeLessThan:
+		case ComparsionModeLessThan:
 			conditionMet = baseValue.LessThan(&itemValue)
-		case ConditionItemModeLessThanOrEqual:
+		case ComparsionModeLessThanOrEqual:
 			conditionMet = baseValue.LessThanOrEqual(&itemValue)
-		case ConditionItemModeContains:
+		case ComparsionModeContains:
 			conditionMet = baseValue.Contains(&itemValue)
+		case ComparsionModeStartsWith:
+			conditionMet = baseValue.StartsWith(&itemValue)
+		case ComparsionModeEndsWith:
+			conditionMet = baseValue.EndsWith(&itemValue)
 		}
 
 		if conditionMet {
@@ -1449,25 +1453,25 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 
 		var conditionMet bool
 		switch n.Data.ConditionItemMode {
-		case ConditionItemModeEqual:
+		case ComparsionModeEqual:
 			conditionMet = baseValue.Equals(&itemValue)
-		case ConditionItemModeNotEqual:
+		case ComparsionModeNotEqual:
 			conditionMet = baseValue.Equals(&itemValue)
-		case ConditionItemModeHasRole:
+		case ComparsionModeHasRole:
 			member := baseValue.DiscordMember()
 			if !member.User.ID.IsValid() {
 				// TODO?: fetch member by id from discord?
 				return nil
 			}
 			conditionMet = slices.Contains(member.RoleIDs, discord.RoleID(itemValue.Int()))
-		case ConditionItemModeNotHasRole:
+		case ComparsionModeNotHasRole:
 			member := baseValue.DiscordMember()
 			if !member.User.ID.IsValid() {
 				// TODO?: fetch member by id from discord?
 				return nil
 			}
 			conditionMet = !slices.Contains(member.RoleIDs, discord.RoleID(itemValue.Int()))
-		case ConditionItemModeHasPermission:
+		case ComparsionModeHasPermission:
 			member := baseValue.DiscordMember()
 			if !member.User.ID.IsValid() {
 				// TODO?: fetch member by id from discord?
@@ -1488,7 +1492,7 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 
 			itemPermissions := discord.Permissions(itemValue.Int())
 			conditionMet = permission&itemPermissions == itemPermissions
-		case ConditionItemModeNotHasPermission:
+		case ComparsionModeNotHasPermission:
 			member := baseValue.DiscordMember()
 			if !member.User.ID.IsValid() {
 				// TODO?: fetch member by id from discord?

--- a/kite-service/pkg/flow/execute_test.go
+++ b/kite-service/pkg/flow/execute_test.go
@@ -114,6 +114,10 @@ func (d *TestContextData) Interaction() *discord.InteractionEvent {
 	return &discord.InteractionEvent{}
 }
 
+func (d *TestContextData) UserID() discord.UserID {
+	return 0
+}
+
 func (d *TestContextData) GuildID() discord.GuildID {
 	return 0
 }

--- a/kite-service/pkg/flow/execute_test.go
+++ b/kite-service/pkg/flow/execute_test.go
@@ -37,7 +37,7 @@ var flowCommandTest = CompiledFlowNode{
 							ID:   "2",
 							Type: FlowNodeTypeControlConditionItemCompare,
 							Data: FlowNodeData{
-								ConditionItemMode:  ConditionItemModeEqual,
+								ConditionItemMode:  ComparsionModeEqual,
 								ConditionItemValue: "null",
 							},
 							Children: ConnectedFlowNodes{

--- a/kite-service/pkg/thing/thing.go
+++ b/kite-service/pkg/thing/thing.go
@@ -645,6 +645,14 @@ func (w Thing) Contains(other *Thing) bool {
 	return strings.Contains(w.String(), other.String())
 }
 
+func (w Thing) StartsWith(other *Thing) bool {
+	return strings.HasPrefix(w.String(), other.String())
+}
+
+func (w Thing) EndsWith(other *Thing) bool {
+	return strings.HasSuffix(w.String(), other.String())
+}
+
 func (w Thing) IsEmpty() bool {
 	return w.String() == "" || w.String() == "0"
 }

--- a/kite-web/src/components/flow/FlowEditor.tsx
+++ b/kite-web/src/components/flow/FlowEditor.tsx
@@ -157,9 +157,16 @@ export default function FlowEditor({
       const target = getNode(con.target)!;
 
       // This is a bit of a mess, but it works for now
-      if (target.type === "entry_command" && !source.type?.startsWith("option"))
+      if (
+        (target.type === "entry_command" || target.type === "entry_event") &&
+        !source.type?.startsWith("option")
+      )
         return false;
-      if (source.type?.startsWith("option") && target.type !== "entry_command")
+      if (
+        source.type?.startsWith("option") &&
+        target.type !== "entry_command" &&
+        target.type !== "entry_event"
+      )
         return false;
 
       // Prevent cycles

--- a/kite-web/src/components/flow/FlowNodeEditor.tsx
+++ b/kite-web/src/components/flow/FlowNodeEditor.tsx
@@ -95,7 +95,7 @@ const intputs: Record<string, any> = {
   command_integrations: CommandIntegrationsInput,
   command_permissions: CommandPermissionsInput,
   event_type: EventTypeInput,
-  event_filter_base_value: EventFilterBaseValueInput,
+  event_filter_target: EventFilterTargetInput,
   event_filter_mode: EventFilterModeInput,
   event_filter_value: EventFilterValueInput,
   message_data: MessageDataInput,
@@ -700,22 +700,22 @@ function EventTypeInput({ data, updateData, errors }: InputProps) {
   );
 }
 
-function EventFilterBaseValueInput({ data, updateData, errors }: InputProps) {
+function EventFilterTargetInput({ data, updateData, errors }: InputProps) {
   return (
     <BaseInput
       type="select"
-      field="condition_base_value"
-      title="Base Field"
+      field="event_filter_target"
+      title="Filter Target"
       options={[
-        { value: "{{message.content}}", label: "Message Content" },
-        { value: "{{user.id}}", label: "User ID" },
-        { value: "{{user.username}}", label: "User Username" },
-        { value: "{{user.display_name}}", label: "User Display Name" },
+        { value: "message_content", label: "Message Content" },
+        { value: "user_id", label: "User ID" },
+        { value: "guild_id", label: "Guild ID" },
+        { value: "channel_id", label: "Channel ID" },
       ]}
-      value={data.condition_base_value || ""}
+      value={data.event_filter_target || ""}
       updateValue={(v) =>
         updateData({
-          condition_base_value: v || undefined,
+          event_filter_target: v || undefined,
         })
       }
       errors={errors}
@@ -727,8 +727,8 @@ function EventFilterModeInput({ data, updateData, errors }: InputProps) {
   return (
     <BaseInput
       type="select"
-      field="condition_item_mode"
-      title="Comparison Mode"
+      field="event_filter_mode"
+      title="Filter Mode"
       options={[
         { value: "equal", label: "Equal" },
         { value: "not_equal", label: "Not Equal" },
@@ -736,8 +736,8 @@ function EventFilterModeInput({ data, updateData, errors }: InputProps) {
         { value: "starts_with", label: "Starts With" },
         { value: "ends_with", label: "Ends With" },
       ]}
-      value={data.condition_item_mode || ""}
-      updateValue={(v) => updateData({ condition_item_mode: v || undefined })}
+      value={data.event_filter_mode || ""}
+      updateValue={(v) => updateData({ event_filter_mode: v || undefined })}
       errors={errors}
     />
   );
@@ -746,12 +746,12 @@ function EventFilterModeInput({ data, updateData, errors }: InputProps) {
 function EventFilterValueInput({ data, updateData, errors }: InputProps) {
   return (
     <BaseInput
-      field="condition_item_value"
-      title="Comparison Value"
-      value={data.condition_item_value || ""}
+      field="event_filter_value"
+      title="Filter Value"
+      value={data.event_filter_value || ""}
       updateValue={(v) =>
         updateData({
-          condition_item_value: v || undefined,
+          event_filter_value: v || undefined,
         })
       }
       errors={errors}

--- a/kite-web/src/components/flow/FlowNodeEditor.tsx
+++ b/kite-web/src/components/flow/FlowNodeEditor.tsx
@@ -95,6 +95,9 @@ const intputs: Record<string, any> = {
   command_integrations: CommandIntegrationsInput,
   command_permissions: CommandPermissionsInput,
   event_type: EventTypeInput,
+  event_filter_base_value: EventFilterBaseValueInput,
+  event_filter_mode: EventFilterModeInput,
+  event_filter_value: EventFilterValueInput,
   message_data: MessageDataInput,
   message_template_id: MessageTemplateInput,
   message_target: MessageTargetInput,
@@ -692,6 +695,65 @@ function EventTypeInput({ data, updateData, errors }: InputProps) {
       ]}
       value={data.event_type || ""}
       updateValue={(v) => updateData({ event_type: v || undefined })}
+      errors={errors}
+    />
+  );
+}
+
+function EventFilterBaseValueInput({ data, updateData, errors }: InputProps) {
+  return (
+    <BaseInput
+      type="select"
+      field="condition_base_value"
+      title="Base Field"
+      options={[
+        { value: "{{message.content}}", label: "Message Content" },
+        { value: "{{user.id}}", label: "User ID" },
+        { value: "{{user.username}}", label: "User Username" },
+        { value: "{{user.display_name}}", label: "User Display Name" },
+      ]}
+      value={data.condition_base_value || ""}
+      updateValue={(v) =>
+        updateData({
+          condition_base_value: v || undefined,
+        })
+      }
+      errors={errors}
+    />
+  );
+}
+
+function EventFilterModeInput({ data, updateData, errors }: InputProps) {
+  return (
+    <BaseInput
+      type="select"
+      field="condition_item_mode"
+      title="Comparison Mode"
+      options={[
+        { value: "equal", label: "Equal" },
+        { value: "not_equal", label: "Not Equal" },
+        { value: "contains", label: "Contains" },
+        { value: "starts_with", label: "Starts With" },
+        { value: "ends_with", label: "Ends With" },
+      ]}
+      value={data.condition_item_mode || ""}
+      updateValue={(v) => updateData({ condition_item_mode: v || undefined })}
+      errors={errors}
+    />
+  );
+}
+
+function EventFilterValueInput({ data, updateData, errors }: InputProps) {
+  return (
+    <BaseInput
+      field="condition_item_value"
+      title="Comparison Value"
+      value={data.condition_item_value || ""}
+      updateValue={(v) =>
+        updateData({
+          condition_item_value: v || undefined,
+        })
+      }
       errors={errors}
     />
   );
@@ -2147,6 +2209,8 @@ function ConditionItemCompareModeInput({
         { value: "greater_than_or_equal", label: "Greater Than or Equal" },
         { value: "less_than_or_equal", label: "Less Than or Equal" },
         { value: "contains", label: "Contains" },
+        { value: "starts_with", label: "Starts With" },
+        { value: "ends_with", label: "Ends With" },
       ]}
       value={data.condition_item_mode || ""}
       updateValue={(v) => updateData({ condition_item_mode: v || undefined })}

--- a/kite-web/src/components/flow/FlowNodeEntryEvent.tsx
+++ b/kite-web/src/components/flow/FlowNodeEntryEvent.tsx
@@ -2,6 +2,7 @@ import { Position } from "@xyflow/react";
 import { NodeProps } from "../../lib/flow/dataSchema";
 import FlowNodeBase from "./FlowNodeBase";
 import FlowNodeHandle from "./FlowNodeHandle";
+import { optionColor } from "@/lib/flow/nodes";
 
 export default function FlowNodeEntryEvent(props: NodeProps) {
   const eventName = props.data.event_type?.split("_").join(" ") || "";
@@ -14,6 +15,11 @@ export default function FlowNodeEntryEvent(props: NodeProps) {
       highlight={true}
       showConnectedMarker={false}
     >
+      <FlowNodeHandle
+        type="target"
+        position={Position.Top}
+        color={optionColor}
+      />
       <FlowNodeHandle type="source" position={Position.Bottom} />
     </FlowNodeBase>
   );

--- a/kite-web/src/components/flow/FlowNodeExplorer.tsx
+++ b/kite-web/src/components/flow/FlowNodeExplorer.tsx
@@ -20,7 +20,7 @@ const nodeCategories = {
     },
     {
       title: "Events",
-      nodeTypes: ["option_command_contexts"],
+      nodeTypes: ["option_event_filter"],
       contextTypes: ["event_discord"],
     },
     /* {

--- a/kite-web/src/lib/flow/dataSchema.ts
+++ b/kite-web/src/lib/flow/dataSchema.ts
@@ -108,9 +108,9 @@ export const nodeOptionCommandContextsSchema = nodeBaseDataSchema.extend({
 });
 
 export const nodeOptionEventFilterSchema = nodeBaseDataSchema.extend({
-  condition_base_value: z.string().regex(placeholderRegex),
-  condition_item_mode: conditionItemModeSchema,
-  condition_item_value: z.string().max(1000).min(1),
+  event_filter_target: z.string(),
+  event_filter_mode: conditionItemModeSchema,
+  event_filter_value: z.string().max(1000).min(1),
 });
 
 export const nodeEntryEventDataSchema = nodeBaseDataSchema.extend({

--- a/kite-web/src/lib/flow/dataSchema.ts
+++ b/kite-web/src/lib/flow/dataSchema.ts
@@ -19,6 +19,21 @@ export type NodeType = Node<NodeData>;
 
 export const auditLogReasonSchema = z.string().max(512).optional();
 
+export const conditionItemModeSchema = z
+  .literal("equal")
+  .or(z.literal("not_equal"))
+  .or(z.literal("greater_than"))
+  .or(z.literal("less_than"))
+  .or(z.literal("greater_than_or_equal"))
+  .or(z.literal("less_than_or_equal"))
+  .or(z.literal("contains"))
+  .or(z.literal("starts_with"))
+  .or(z.literal("ends_with"))
+  .or(z.literal("has_role"))
+  .or(z.literal("not_has_role"))
+  .or(z.literal("has_permission"))
+  .or(z.literal("not_has_permission"));
+
 export const nodeBaseDataSchema = z.object({
   custom_label: z.string().optional(),
   result_key: z
@@ -93,8 +108,9 @@ export const nodeOptionCommandContextsSchema = nodeBaseDataSchema.extend({
 });
 
 export const nodeOptionEventFilterSchema = nodeBaseDataSchema.extend({
-  event_filter_target: z.literal("message_content"),
-  event_filter_expression: z.string().max(1000).min(1),
+  condition_base_value: z.string().regex(placeholderRegex),
+  condition_item_mode: conditionItemModeSchema,
+  condition_item_value: z.string().max(1000).min(1),
 });
 
 export const nodeEntryEventDataSchema = nodeBaseDataSchema.extend({
@@ -650,18 +666,7 @@ export const nodeConditionCompareDataSchema = nodeBaseDataSchema.extend({
 
 export const nodeConditionItemCompareDataSchema = nodeBaseDataSchema.extend({
   condition_item_value: z.string().optional(),
-  condition_item_mode: z
-    .literal("equal")
-    .or(z.literal("not_equal"))
-    .or(z.literal("greater_than"))
-    .or(z.literal("less_than"))
-    .or(z.literal("greater_than_or_equal"))
-    .or(z.literal("less_than_or_equal"))
-    .or(z.literal("contains"))
-    .or(z.literal("has_role"))
-    .or(z.literal("not_has_role"))
-    .or(z.literal("has_permission"))
-    .or(z.literal("not_has_permission")),
+  condition_item_mode: conditionItemModeSchema,
 });
 
 export const nodeControlLoopDataSchema = nodeBaseDataSchema.extend({

--- a/kite-web/src/lib/flow/nodes.ts
+++ b/kite-web/src/lib/flow/nodes.ts
@@ -845,7 +845,7 @@ export const nodeTypes: Record<string, NodeValues> = {
     defaultDescription: "Filter events based on their properties.",
     dataSchema: nodeOptionEventFilterSchema,
     dataFields: [
-      "event_filter_base_value",
+      "event_filter_target",
       "event_filter_mode",
       "event_filter_value",
     ],

--- a/kite-web/src/lib/flow/nodes.ts
+++ b/kite-web/src/lib/flow/nodes.ts
@@ -844,7 +844,11 @@ export const nodeTypes: Record<string, NodeValues> = {
     defaultTitle: "Event Filter",
     defaultDescription: "Filter events based on their properties.",
     dataSchema: nodeOptionEventFilterSchema,
-    dataFields: ["event_filter_target", "event_filter_expression"],
+    dataFields: [
+      "event_filter_base_value",
+      "event_filter_mode",
+      "event_filter_value",
+    ],
   },
   suspend_response_modal: {
     color: suspendColor,

--- a/kite-web/src/lib/types/flow.gen.ts
+++ b/kite-web/src/lib/types/flow.gen.ts
@@ -66,6 +66,7 @@ export const FlowNodeTypeControlConditionItemChannel: FlowNodeType = "control_co
 export const FlowNodeTypeControlConditionRole: FlowNodeType = "control_condition_role";
 export const FlowNodeTypeControlConditionItemRole: FlowNodeType = "control_condition_item_role";
 export const FlowNodeTypeControlConditionItemElse: FlowNodeType = "control_condition_item_else";
+export const FlowNodeTypeControlErrorHandler: FlowNodeType = "control_error_handler";
 export const FlowNodeTypeControlLoop: FlowNodeType = "control_loop";
 export const FlowNodeTypeControlLoopEach: FlowNodeType = "control_loop_each";
 export const FlowNodeTypeControlLoopEnd: FlowNodeType = "control_loop_end";
@@ -180,7 +181,8 @@ export interface FlowNodeData {
    * Event Filter
    */
   event_filter_target?: EventFilterTarget;
-  event_filter_expression?: string;
+  event_filter_mode?: ComparsionMode;
+  event_filter_value?: string;
   /**
    * Log
    */
@@ -195,7 +197,7 @@ export interface FlowNodeData {
    */
   condition_base_value?: string;
   condition_allow_multiple?: boolean;
-  condition_item_mode?: ConditionItemType;
+  condition_item_mode?: ComparsionMode;
   condition_item_value?: string;
   /**
    * Loop
@@ -206,21 +208,23 @@ export interface FlowNodeData {
    */
   sleep_duration_seconds?: string;
 }
-export type ConditionItemType = string;
-export const ConditionItemModeEqual: ConditionItemType = "equal";
-export const ConditionItemModeNotEqual: ConditionItemType = "not_equal";
-export const ConditionItemModeGreaterThan: ConditionItemType = "greater_than";
-export const ConditionItemModeGreaterThanOrEqual: ConditionItemType = "greater_than_or_equal";
-export const ConditionItemModeLessThan: ConditionItemType = "less_than";
-export const ConditionItemModeLessThanOrEqual: ConditionItemType = "less_than_or_equal";
-export const ConditionItemModeContains: ConditionItemType = "contains";
+export type ComparsionMode = string;
+export const ComparsionModeEqual: ComparsionMode = "equal";
+export const ComparsionModeNotEqual: ComparsionMode = "not_equal";
+export const ComparsionModeGreaterThan: ComparsionMode = "greater_than";
+export const ComparsionModeGreaterThanOrEqual: ComparsionMode = "greater_than_or_equal";
+export const ComparsionModeLessThan: ComparsionMode = "less_than";
+export const ComparsionModeLessThanOrEqual: ComparsionMode = "less_than_or_equal";
+export const ComparsionModeContains: ComparsionMode = "contains";
+export const ComparsionModeStartsWith: ComparsionMode = "starts_with";
+export const ComparsionModeEndsWith: ComparsionMode = "ends_with";
 /**
  * User condition
  */
-export const ConditionItemModeHasRole: ConditionItemType = "has_role";
-export const ConditionItemModeNotHasRole: ConditionItemType = "not_has_role";
-export const ConditionItemModeHasPermission: ConditionItemType = "has_permission";
-export const ConditionItemModeNotHasPermission: ConditionItemType = "not_has_permission";
+export const ComparsionModeHasRole: ComparsionMode = "has_role";
+export const ComparsionModeNotHasRole: ComparsionMode = "not_has_role";
+export const ComparsionModeHasPermission: ComparsionMode = "has_permission";
+export const ComparsionModeNotHasPermission: ComparsionMode = "not_has_permission";
 export type CommandArgumentType = string;
 export const CommandArgumentTypeString: CommandArgumentType = "string";
 export const CommandArgumentTypeInteger: CommandArgumentType = "integer";
@@ -240,6 +244,9 @@ export const CommandDisabledIntegrationTypeGuildInstall: CommandDisabledIntegrat
 export const CommandDisabledIntegrationTypeUserInstall: CommandDisabledIntegrationType = "user_install";
 export type EventFilterTarget = string;
 export const EventFilterTypeMessageContent: EventFilterTarget = "message_content";
+export const EventFilterTypeUserID: EventFilterTarget = "user_id";
+export const EventFilterTypeGuildID: EventFilterTarget = "guild_id";
+export const EventFilterTypeChannelID: EventFilterTarget = "channel_id";
 export type RobloxLookupType = string;
 export const RobloxLookupTypeID: RobloxLookupType = "id";
 export const RobloxLookupTypeName: RobloxLookupType = "username";


### PR DESCRIPTION
Implements the event filter node which allows filtering events before the flow starts executing.

This PR also adds two new comparison modes: `starts_with` & `ends_with`