### PR TITLE
fix(ui): correct typo in deployment status message

### DIFF
--- a/kite-web/src/components/flow/FlowNav.tsx
+++ b/kite-web/src/components/flow/FlowNav.tsx
@@ -96,7 +96,7 @@ export default function FlowNav({
         ) : hasUndeployedChanges === false ? (
           <div className="flex space-x-2 text-foreground/70 items-center">
             <CheckIcon className="h-5 w-5" />
-            <div>Changed Deployed</div>
+            <div>Changes Deployed</div>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
> <img alt="Image" width="1153" height="461" src="https://private-user-images.githubusercontent.com/202195058/548025941-2b3a1455-b30d-40d8-a357-f3001b0fce3d.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5NTcxNTIsIm5iZiI6MTc3MDk1Njg1MiwicGF0aCI6Ii8yMDIxOTUwNTgvNTQ4MDI1OTQxLTJiM2ExNDU1LWIzMGQtNDBkOC1hMzU3LWYzMDAxYjBmY2UzZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMjEzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDIxM1QwNDI3MzJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1lNDllYTVkYjg1MmZmYjQzNjZkMTNhMjEyMjIyOWIwMjZhNGU5ODY1OTBjYThjNTAwZjhhMDI3NDkzYTdiMzIzJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.pWM9UqKdGfI9eX6wnvvTQnzBYCZ2dB_kCVx2w7RlSqk"> I believe it is supposed to say "Changes Deployed"

Corrects a grammatical error in the deployment status message within the Flow navigation component. The text "Changed Deployed" has been updated to "Changes Deployed" to properly indicate that changes have been successfully deployed.

