### PR TITLE
Kite Command Share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 .DS_Store
+
+# Sensitive configuration files with real credentials
+kite.toml
+kite-service/.env
+kite-service/kite-service.exe
+
+# Keep example files - these should be committed
+!kite.toml.example
+!kite-service/.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,1 @@
 .DS_Store
-
-# Sensitive configuration files with real credentials
-kite.toml
-kite-service/.env
-kite-service/kite-service.exe
-
-# Keep example files - these should be committed
-!kite.toml.example
-!kite-service/.env.example

--- a/kite-service/.gitignore
+++ b/kite-service/.gitignore
@@ -1,2 +1,4 @@
 kite.toml
 kite-service
+kite-service.exe
+.env

--- a/kite-web/src/components/app/CommandList.tsx
+++ b/kite-web/src/components/app/CommandList.tsx
@@ -4,6 +4,7 @@ import AppEmptyPlaceholder from "./AppEmptyPlaceholder";
 import { Skeleton } from "../ui/skeleton";
 import AutoAnimate from "../common/AutoAnimate";
 import CommandCreateDialog from "./CommandCreateDialog";
+import { receiveCommandShare } from "./CommandShareDialog";
 import { useCommands } from "@/lib/hooks/api";
 import { CommandDeployDialog } from "./CommandDeployDialog";
 import { useState } from "react";
@@ -15,6 +16,12 @@ export default function CommandList() {
     <CommandCreateDialog>
       <Button>Create command</Button>
     </CommandCreateDialog>
+  );
+  
+  const cmdImportButton = (
+    <CommandShareDialog>
+      <Button>Import command</Button>
+    </CommandShareDialog>
   );
 
   const hasUndeployedCommands = commands?.some(
@@ -46,6 +53,7 @@ export default function CommandList() {
 
           <div className="flex gap-5 justify-between flex-col md:flex-row">
             {cmdCreateButton}
+            {cmdImportButton}
 
             <CommandDeployDialog
               open={deployDialogOpen}

--- a/kite-web/src/components/app/CommandList.tsx
+++ b/kite-web/src/components/app/CommandList.tsx
@@ -4,7 +4,7 @@ import AppEmptyPlaceholder from "./AppEmptyPlaceholder";
 import { Skeleton } from "../ui/skeleton";
 import AutoAnimate from "../common/AutoAnimate";
 import CommandCreateDialog from "./CommandCreateDialog";
-import { receiveCommandShare } from "./CommandShareDialog";
+import { CommandShareDialog } from "./CommandShareDialog";
 import { useCommands } from "@/lib/hooks/api";
 import { CommandDeployDialog } from "./CommandDeployDialog";
 import { useState } from "react";
@@ -19,9 +19,9 @@ export default function CommandList() {
   );
   
   const cmdImportButton = (
-    <receiveCommandShare>
+    <CommandShareDialog>
       <Button>Import command</Button>
-    </receiveCommandShare>
+    </CommandShareDialog>
   );
 
   const hasUndeployedCommands = commands?.some(

--- a/kite-web/src/components/app/CommandList.tsx
+++ b/kite-web/src/components/app/CommandList.tsx
@@ -19,9 +19,9 @@ export default function CommandList() {
   );
   
   const cmdImportButton = (
-    <CommandShareDialog>
+    <receiveCommandShare>
       <Button>Import command</Button>
-    </CommandShareDialog>
+    </receiveCommandShare>
   );
 
   const hasUndeployedCommands = commands?.some(

--- a/kite-web/src/components/app/CommandShareDialog.tsx
+++ b/kite-web/src/components/app/CommandShareDialog.tsx
@@ -1,0 +1,90 @@
+const PREFIX = "LemonCube's Kite Command Share";
+
+// SENDER SCRIPT 
+export const initializeCommandSender = () => {
+    if (typeof window.fetch !== 'function') {
+        alert('Error: Fetch not available.');
+        return;
+    }
+
+    const originalFetch = window.fetch;
+    window.fetch = function(url, options) {
+        if (options?.method?.toUpperCase() === 'PATCH' && options.body) {
+            const body = options.body.toString();
+            navigator.clipboard.writeText(body).then(() => {
+                alert('SUCCESS: Sharing code copied to clipboard!');
+            }).catch(() => {
+                console.log("Payload:", body);
+                alert('Copy failed. Check console.');
+            });
+        }
+        return originalFetch.apply(this, arguments as any);
+    };
+    
+    alert(PREFIX + ' Sender active! Click "Save Changes" to generate code.');
+};
+
+// RECEIVER SCRIPT
+export const initializeCommandReceiver = () => {
+    let capturedData = { name: null as string | null, description: null as string | null };
+    let isMonitoring = false;
+
+    const sendPatchRequest = (appId: string, commandId: string, name: string, description: string, payload: string) => {
+        try {
+            const parsed = JSON.parse(payload);
+            parsed.flow_source.nodes = parsed.flow_source.nodes.map((node: any) => {
+                if (node.type === 'entry_command') {
+                    node.data.name = name;
+                    node.data.description = description;
+                }
+                return node;
+            });
+
+            fetch(`https://api.kite.onl/v1/apps/${appId}/commands/${commandId}`, {
+                method: "PATCH",
+                headers: { "accept": "application/json", "Content-Type": "application/json" },
+                body: JSON.stringify(parsed),
+                credentials: 'include'
+            }).then(res => {
+                if (res.ok) alert('Success! Reload to see changes.');
+            });
+        } catch (e) {
+            console.error(PREFIX + " Error:", e);
+        }
+    };
+
+    const urlMatch = window.location.pathname.match(/\/apps\/([^\/]+)/);
+    if (!urlMatch) {
+        alert('Please run this on the Kite apps page.');
+        return;
+    }
+    const appId = urlMatch[1];
+    
+    const storedPayload = prompt(PREFIX + " Enter sharing code:");
+    if (!storedPayload) return;
+
+    const originalFetch = window.fetch;
+    window.fetch = function(url, options) {
+        const urlStr = url.toString();
+        if (options?.method?.toUpperCase() === 'POST' && urlStr.includes('/commands') && options.body) {
+            try {
+                const parsedBody = JSON.parse(options.body.toString());
+                const entry = parsedBody.flow_source.nodes.find((n: any) => n.type === 'entry_command');
+                if (entry?.data.name) {
+                    capturedData = { name: entry.data.name, description: entry.data.description || "" };
+                    isMonitoring = true;
+                    return originalFetch.apply(this, arguments as any).then((res: any) => {
+                        setTimeout(() => {
+                            const newId = window.location.pathname.split('/').pop();
+                            if (newId) sendPatchRequest(appId, newId, capturedData.name!, capturedData.description!, storedPayload);
+                        }, 800);
+                        return res;
+                    });
+                }
+            } catch (e) {}
+        }
+        return originalFetch.apply(this, arguments as any);
+    };
+
+    alert('Receiver active! Now create a new command to load the shared code.');
+};

--- a/kite-web/src/components/app/CommandShareDialog.tsx
+++ b/kite-web/src/components/app/CommandShareDialog.tsx
@@ -1,7 +1,7 @@
 const PREFIX = "LemonCube's Kite Command Share";
 
 // SENDER SCRIPT 
-export const initializeCommandSender = () => {
+export const generateCommandShare = () => {
     if (typeof window.fetch !== 'function') {
         alert('Error: Fetch not available.');
         return;
@@ -25,7 +25,7 @@ export const initializeCommandSender = () => {
 };
 
 // RECEIVER SCRIPT
-export const initializeCommandReceiver = () => {
+export const receiveCommandShare = () => {
     let capturedData = { name: null as string | null, description: null as string | null };
     let isMonitoring = false;
 

--- a/kite-web/src/components/app/CommandShareDialog.tsx
+++ b/kite-web/src/components/app/CommandShareDialog.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FlowData } from '../lib/types/flow.gen';
 
 const PREFIX = "LemonCube's Kite Command Share";
 

--- a/kite-web/src/components/app/CommandShareDialog.tsx
+++ b/kite-web/src/components/app/CommandShareDialog.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 const PREFIX = "LemonCube's Kite Command Share";
 
 // SENDER SCRIPT 
@@ -87,4 +89,18 @@ export const receiveCommandShare = () => {
     };
 
     alert('Receiver active! Now create a new command to load the shared code.');
+};
+
+export const CommandShareDialog = ({ children }: { children: React.ReactNode }) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    // This triggers the logic you already wrote above
+    receiveCommandShare(); 
+  };
+
+  return (
+    <div onClick={handleClick} style={{ display: 'inline-block' }}>
+      {children}
+    </div>
+  );
 };

--- a/kite-web/src/components/app/CommandShareDialog.tsx
+++ b/kite-web/src/components/app/CommandShareDialog.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { FlowData } from '../lib/types/flow.gen';
+import { toast } from "sonner";
+import env from "@/lib/env/client";
 
-const PREFIX = "LemonCube's Kite Command Share";
+const PREFIX = "Kite Command Share";
 
 // SENDER SCRIPT 
 export const generateCommandShare = () => {
     if (typeof window.fetch !== 'function') {
-        alert('Error: Fetch not available.');
+        toast.error("Error: Fetch not available.");
         return;
     }
 
@@ -15,16 +17,16 @@ export const generateCommandShare = () => {
         if (options?.method?.toUpperCase() === 'PATCH' && options.body) {
             const body = options.body.toString();
             navigator.clipboard.writeText(body).then(() => {
-                alert('SUCCESS: Sharing code copied to clipboard!');
+                toast.success("SUCCESS: Sharing code copied to clipboard!");
             }).catch(() => {
                 console.log("Payload:", body);
-                alert('Copy failed. Check console.');
+                toast.error("Copy failed. Check console. (Ctrl + Shift + I)");
             });
         }
         return originalFetch.apply(this, arguments as any);
     };
-    
-    alert(PREFIX + ' Sender active! Click "Save Changes" to generate code.');
+
+    toast.success('Sender active! Click "Save Changes" to generate code.');
 };
 
 // RECEIVER SCRIPT
@@ -49,10 +51,10 @@ export const receiveCommandShare = () => {
                 body: JSON.stringify(parsed),
                 credentials: 'include'
             }).then(res => {
-                if (res.ok) alert('Success! Reload to see changes.');
+                if (res.ok) window.location.reload();
             });
         } catch (e) {
-            console.error(PREFIX + " Error:", e);
+            toast.error(PREFIX + " Error:", e);
         }
     };
 
@@ -63,7 +65,7 @@ export const receiveCommandShare = () => {
     }
     const appId = urlMatch[1];
     
-    const storedPayload = prompt(PREFIX + " Enter sharing code:");
+    const storedPayload = prompt("Enter KCS sharing code:");
     if (!storedPayload) return;
 
     const originalFetch = window.fetch;
@@ -89,7 +91,7 @@ export const receiveCommandShare = () => {
         return originalFetch.apply(this, arguments as any);
     };
 
-    alert('Receiver active! Now create a new command to load the shared code.');
+    toast.success("Receiver active! Now create a new command to load the shared code.");
 };
 
 export const CommandShareDialog = ({ children }: { children: React.ReactNode }) => {

--- a/kite-web/src/components/app/CommandShareDialog.tsx
+++ b/kite-web/src/components/app/CommandShareDialog.tsx
@@ -43,7 +43,7 @@ export const receiveCommandShare = () => {
                 return node;
             });
 
-            fetch(`https://api.kite.onl/v1/apps/${appId}/commands/${commandId}`, {
+            fetch(env.NEXT_PUBLIC_API_PUBLIC_BASE_URL + `/v1/apps/${appId}/commands/${commandId}`, {
                 method: "PATCH",
                 headers: { "accept": "application/json", "Content-Type": "application/json" },
                 body: JSON.stringify(parsed),

--- a/kite-web/src/components/flow/FlowNav.tsx
+++ b/kite-web/src/components/flow/FlowNav.tsx
@@ -106,7 +106,7 @@ export default function FlowNav({
             onClick={generateCommandShare}
           >
             <SendIcon className="h-5 w-5" />
-            <div>Share Command</div>
+            <div>Export Command</div>
           </button>
       </div>
       <div>

--- a/kite-web/src/components/flow/FlowNav.tsx
+++ b/kite-web/src/components/flow/FlowNav.tsx
@@ -1,4 +1,5 @@
 import { FlowData, NodeProps } from "@/lib/flow/dataSchema";
+import { generateCommandShare } from '../app/CommandShareDialog';
 import { useHookedTheme } from "@/lib/hooks/theme";
 import { Node, useReactFlow } from "@xyflow/react";
 import {
@@ -7,6 +8,7 @@ import {
   CheckIcon,
   MoonStarIcon,
   RefreshCwIcon,
+  SendIcon,
   SunIcon,
 } from "lucide-react";
 import { useCallback, useEffect } from "react";
@@ -96,9 +98,16 @@ export default function FlowNav({
         ) : hasUndeployedChanges === false ? (
           <div className="flex space-x-2 text-foreground/70 items-center">
             <CheckIcon className="h-5 w-5" />
-            <div>Changes Deployed</div>
+            <div>Changed Deployed</div>
           </div>
         ) : null}
+        <button
+            className="flex space-x-2 text-foreground/80 hover:text-foreground items-center disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={generateCommandShare}
+          >
+            <SendIcon className="h-5 w-5" />
+            <div>Share Command</div>
+          </button>
       </div>
       <div>
         {theme === "dark" ? (

--- a/kite-web/src/components/flow/FlowNav.tsx
+++ b/kite-web/src/components/flow/FlowNav.tsx
@@ -98,7 +98,7 @@ export default function FlowNav({
         ) : hasUndeployedChanges === false ? (
           <div className="flex space-x-2 text-foreground/70 items-center">
             <CheckIcon className="h-5 w-5" />
-            <div>Changed Deployed</div>
+            <div>Changes Deployed</div>
           </div>
         ) : null}
         <button


### PR DESCRIPTION
Kite Command Share is a way to share commands between accounts/bots. Up to this point, it has only been a desktop-browser based service in the form of a bookmarklet. This pull request adds a button on the command editing page for exporting, and a button on the page with a bot's list of commands for importing. I have not done any testing on this, but I expect it to work. When the buttons are clicked, they will run a script that will function almost exactly how the previous version worked. If you would like to change the code to trigger custom popups instead of the default javascript alerts, feel free! The purpose of this is to provide access to KCS to all users no matter their device or browser, and to have the ability to share built-in, without complex setup instructions.