### PR TITLE
Change Embedded Timestamps from “date” to “text”.

### DIFF
--- a/kite-web/src/components/message/MessageEmbedFooter.tsx
+++ b/kite-web/src/components/message/MessageEmbedFooter.tsx
@@ -16,12 +16,14 @@ export default function MessageEmbedFooter({
       state.setEmbedFooterText,
     ])
   );
+
   const [iconUrl, setIconUrl] = useCurrentMessage(
     useShallow((state) => [
       state.embeds[embedIndex]?.footer?.icon_url,
       state.setEmbedFooterIconUrl,
     ])
   );
+
   const [timestamp, setTimestamp] = useCurrentMessage(
     useShallow((state) => [
       state.embeds[embedIndex]?.timestamp,
@@ -45,6 +47,7 @@ export default function MessageEmbedFooter({
         validationPath={`embeds.${embedIndex}.footer.text`}
         placeholders
       />
+
       <div className="flex space-x-3">
         <MessageInput
           type="url"
@@ -54,11 +57,83 @@ export default function MessageEmbedFooter({
           validationPath={`embeds.${embedIndex}.footer.icon_url`}
           imageUpload
         />
+
         <MessageInput
           type="text"
-          label="Timestamp"
-          value={timestamp}
-          onChange={(v) => setTimestamp(embedIndex, v)}
+          label="Timestamp (Unix, ISO, Discord Expression)"
+          value={timestamp || ""}
+          onChange={(v) => {
+            if (!v) {
+              setTimestamp(embedIndex, undefined);
+              return;
+            }
+
+            let input = v.trim();
+            
+            // Allow Discord <t:...:format> expressions literally
+            if (/^<t:.*?:[RrTtDdFf]?>$/.test(input)) {
+              setTimestamp(embedIndex, input);
+              return;
+            }
+            
+            input = input.replace(/\{\{now\(\)\.Unix\(\)\}\}/g, () =>
+              Math.floor(Date.now() / 1000).toString()
+            );
+
+            // Resolve timezone formatting expressions
+            // Example: {{now().In(timezone("America/Chicago")).Format("02/01/2006 03:04 PM")}}
+            const timezoneMatch = input.match(
+              /\{\{now\(\)\.In\(timezone\("(.+?)"\)\)\.Format\("(.+?)"\)\}\}/
+            );
+
+            if (timezoneMatch) {
+              const tz = timezoneMatch[1];
+              const fmt = timezoneMatch[2];
+
+              try {
+                const date = new Date();
+                const options: Intl.DateTimeFormatOptions = {};
+
+                if (fmt.includes("PM") || fmt.includes("AM") || fmt.includes("03") || fmt.includes("04")) {
+                  options.hour = "2-digit";
+                  options.minute = "2-digit";
+                  if (fmt.includes("00")) options.second = "2-digit";
+                }
+                if (fmt.includes("02") || fmt.includes("01") || fmt.includes("2006")) {
+                  options.year = "numeric";
+                  options.month = "2-digit";
+                  options.day = "2-digit";
+                }
+
+                input = new Intl.DateTimeFormat("en-US", {
+                  ...options,
+                  timeZone: tz,
+                }).format(date);
+
+              } catch {
+               
+              }
+            }
+
+            if (/^\d+$/.test(input)) {
+              const unix = Number(input);
+              const date =
+                input.length === 13
+                  ? new Date(unix)
+                  : new Date(unix * 1000);
+
+              if (!isNaN(date.getTime())) {
+                setTimestamp(embedIndex, date.toISOString());
+              }
+
+              return;
+            }
+
+            const parsed = new Date(input);
+            if (!isNaN(parsed.getTime())) {
+              setTimestamp(embedIndex, parsed.toISOString());
+            }
+          }}
           validationPath={`embeds.${embedIndex}.timestamp`}
         />
       </div>

--- a/kite-web/src/components/message/MessageEmbedFooter.tsx
+++ b/kite-web/src/components/message/MessageEmbedFooter.tsx
@@ -47,7 +47,6 @@ export default function MessageEmbedFooter({
         validationPath={`embeds.${embedIndex}.footer.text`}
         placeholders
       />
-
       <div className="flex space-x-3">
         <MessageInput
           type="url"
@@ -57,82 +56,42 @@ export default function MessageEmbedFooter({
           validationPath={`embeds.${embedIndex}.footer.icon_url`}
           imageUpload
         />
-
         <MessageInput
           type="text"
           label="Timestamp"
           value={timestamp || ""}
           onChange={(v) => {
-            if (!v) {
-              setTimestamp(embedIndex, undefined);
-              return;
-            }
-
+            if (!v) return setTimestamp(embedIndex, undefined);
             let input = v.trim();
-            
-            // Allow Discord <t:...:format> expressions
-            if (/^<t:.*?:[RrTtDdFf]?>$/.test(input)) {
-              setTimestamp(embedIndex, input);
-              return;
-            }
-            
+            if (/^<t:.*?:[RrTtDdFf]?>$/.test(input)) return setTimestamp(embedIndex, input);
             input = input.replace(/\{\{now\(\)\.Unix\(\)\}\}/g, () =>
               Math.floor(Date.now() / 1000).toString()
             );
-
-            // Resolve timezone formatting expressions
-            // Example: {{now().In(timezone("America/Chicago")).Format("02/01/2006 03:04 PM")}}
             const timezoneMatch = input.match(
               /\{\{now\(\)\.In\(timezone\("(.+?)"\)\)\.Format\("(.+?)"\)\}\}/
             );
-
             if (timezoneMatch) {
-              const tz = timezoneMatch[1];
-              const fmt = timezoneMatch[2];
-
+              const tz = timezoneMatch[1], fmt = timezoneMatch[2];
               try {
                 const date = new Date();
                 const options: Intl.DateTimeFormatOptions = {};
-
                 if (fmt.includes("PM") || fmt.includes("AM") || fmt.includes("03") || fmt.includes("04")) {
-                  options.hour = "2-digit";
-                  options.minute = "2-digit";
+                  options.hour = "2-digit"; options.minute = "2-digit";
                   if (fmt.includes("00")) options.second = "2-digit";
                 }
                 if (fmt.includes("02") || fmt.includes("01") || fmt.includes("2006")) {
-                  options.year = "numeric";
-                  options.month = "2-digit";
-                  options.day = "2-digit";
+                  options.year = "numeric"; options.month = "2-digit"; options.day = "2-digit";
                 }
-
-                input = new Intl.DateTimeFormat("en-US", {
-                  ...options,
-                  timeZone: tz,
-                }).format(date);
-
-              } catch {
-               
-              }
+                input = new Intl.DateTimeFormat("en-US", { ...options, timeZone: tz }).format(date);
+              } catch {}
             }
-
             if (/^\d+$/.test(input)) {
               const unix = Number(input);
-              const date =
-                input.length === 13
-                  ? new Date(unix)
-                  : new Date(unix * 1000);
-
-              if (!isNaN(date.getTime())) {
-                setTimestamp(embedIndex, date.toISOString());
-              }
-
-              return;
+              const date = input.length === 13 ? new Date(unix) : new Date(unix * 1000);
+              if (!isNaN(date.getTime())) return setTimestamp(embedIndex, date.toISOString());
             }
-
             const parsed = new Date(input);
-            if (!isNaN(parsed.getTime())) {
-              setTimestamp(embedIndex, parsed.toISOString());
-            }
+            if (!isNaN(parsed.getTime())) setTimestamp(embedIndex, parsed.toISOString());
           }}
           validationPath={`embeds.${embedIndex}.timestamp`}
         />

--- a/kite-web/src/components/message/MessageEmbedFooter.tsx
+++ b/kite-web/src/components/message/MessageEmbedFooter.tsx
@@ -55,7 +55,7 @@ export default function MessageEmbedFooter({
           imageUpload
         />
         <MessageInput
-          type="date"
+          type="text"
           label="Timestamp"
           value={timestamp}
           onChange={(v) => setTimestamp(embedIndex, v)}

--- a/kite-web/src/components/message/MessageEmbedFooter.tsx
+++ b/kite-web/src/components/message/MessageEmbedFooter.tsx
@@ -16,14 +16,12 @@ export default function MessageEmbedFooter({
       state.setEmbedFooterText,
     ])
   );
-
   const [iconUrl, setIconUrl] = useCurrentMessage(
     useShallow((state) => [
       state.embeds[embedIndex]?.footer?.icon_url,
       state.setEmbedFooterIconUrl,
     ])
   );
-
   const [timestamp, setTimestamp] = useCurrentMessage(
     useShallow((state) => [
       state.embeds[embedIndex]?.timestamp,
@@ -31,11 +29,26 @@ export default function MessageEmbedFooter({
     ])
   );
 
+  const handleTimestamp = (v: string) => {
+    if (!v) return setTimestamp(embedIndex, undefined);
+    let input = v.trim();
+    if (/^<t:\d+:[RrTtDdFf]?>$/.test(input)) return setTimestamp(embedIndex, input);
+    input = input.replace(/\{\{now\(\)\.Unix\(\)\}\}/g, () => Math.floor(Date.now() / 1000).toString());
+    if (/^\d+$/.test(input)) {
+      const unix = Number(input);
+      const date = input.length === 13 ? new Date(unix) : new Date(unix * 1000);
+      if (!isNaN(date.getTime())) return setTimestamp(embedIndex, date.toISOString());
+    }
+    const parsed = new Date(input);
+    if (!isNaN(parsed.getTime())) return setTimestamp(embedIndex, parsed.toISOString());
+    setTimestamp(embedIndex, input);
+  };
+
   return (
     <CollapsibleSection
       title="Footer"
       size="md"
-      valiationPathPrefix={`embeds.${embedIndex}.footer`}
+      validationPathPrefix={`embeds.${embedIndex}.footer`}
       className="space-y-3"
     >
       <MessageInput
@@ -60,39 +73,7 @@ export default function MessageEmbedFooter({
           type="text"
           label="Timestamp"
           value={timestamp || ""}
-          onChange={(v) => {
-            if (!v) return setTimestamp(embedIndex, undefined);
-            let input = v.trim();
-            if (/^<t:.*?:[RrTtDdFf]?>$/.test(input)) return setTimestamp(embedIndex, input);
-            input = input.replace(/\{\{now\(\)\.Unix\(\)\}\}/g, () =>
-              Math.floor(Date.now() / 1000).toString()
-            );
-            const timezoneMatch = input.match(
-              /\{\{now\(\)\.In\(timezone\("(.+?)"\)\)\.Format\("(.+?)"\)\}\}/
-            );
-            if (timezoneMatch) {
-              const tz = timezoneMatch[1], fmt = timezoneMatch[2];
-              try {
-                const date = new Date();
-                const options: Intl.DateTimeFormatOptions = {};
-                if (fmt.includes("PM") || fmt.includes("AM") || fmt.includes("03") || fmt.includes("04")) {
-                  options.hour = "2-digit"; options.minute = "2-digit";
-                  if (fmt.includes("00")) options.second = "2-digit";
-                }
-                if (fmt.includes("02") || fmt.includes("01") || fmt.includes("2006")) {
-                  options.year = "numeric"; options.month = "2-digit"; options.day = "2-digit";
-                }
-                input = new Intl.DateTimeFormat("en-US", { ...options, timeZone: tz }).format(date);
-              } catch {}
-            }
-            if (/^\d+$/.test(input)) {
-              const unix = Number(input);
-              const date = input.length === 13 ? new Date(unix) : new Date(unix * 1000);
-              if (!isNaN(date.getTime())) return setTimestamp(embedIndex, date.toISOString());
-            }
-            const parsed = new Date(input);
-            if (!isNaN(parsed.getTime())) setTimestamp(embedIndex, parsed.toISOString());
-          }}
+          onChange={handleTimestamp}
           validationPath={`embeds.${embedIndex}.timestamp`}
         />
       </div>

--- a/kite-web/src/components/message/MessageEmbedFooter.tsx
+++ b/kite-web/src/components/message/MessageEmbedFooter.tsx
@@ -60,7 +60,7 @@ export default function MessageEmbedFooter({
 
         <MessageInput
           type="text"
-          label="Timestamp (Unix, ISO, Discord Expression)"
+          label="Timestamp"
           value={timestamp || ""}
           onChange={(v) => {
             if (!v) {

--- a/kite-web/src/components/message/MessageEmbedFooter.tsx
+++ b/kite-web/src/components/message/MessageEmbedFooter.tsx
@@ -70,7 +70,7 @@ export default function MessageEmbedFooter({
 
             let input = v.trim();
             
-            // Allow Discord <t:...:format> expressions literally
+            // Allow Discord <t:...:format> expressions
             if (/^<t:.*?:[RrTtDdFf]?>$/.test(input)) {
               setTimestamp(embedIndex, input);
               return;


### PR DESCRIPTION
This allows the use of Unix Timestamps to use Unix.now and other variations of Unix times.