### PR TITLE
Support for dropdowns with kite

### DIFF
--- a/kite-service/internal/api/wire/message.go
+++ b/kite-service/internal/api/wire/message.go
@@ -43,6 +43,15 @@ func (req *MessageCreateRequest) Sanitize() {
 			if ok {
 				newFlowSources[comp.FlowSourceID] = flow
 			}
+			// Also preserve per-option flow sources for select menus
+			for _, opt := range comp.Options {
+				if opt.FlowSourceID != "" {
+					flow, ok := req.FlowSources[opt.FlowSourceID]
+					if ok {
+						newFlowSources[opt.FlowSourceID] = flow
+					}
+				}
+			}
 		}
 	}
 
@@ -91,6 +100,15 @@ func (req *MessageUpdateRequest) Sanitize() {
 			flow, ok := req.FlowSources[comp.FlowSourceID]
 			if ok {
 				newFlowSources[comp.FlowSourceID] = flow
+			}
+			// Also preserve per-option flow sources for select menus
+			for _, opt := range comp.Options {
+				if opt.FlowSourceID != "" {
+					flow, ok := req.FlowSources[opt.FlowSourceID]
+					if ok {
+						newFlowSources[opt.FlowSourceID] = flow
+					}
+				}
 			}
 		}
 	}

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -288,6 +288,83 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 			}
 
 			go instance.HandleEvent(appID, session, event)
+		case *discord.StringSelectInteraction:
+			// Select menus use the same resume-point system as buttons.
+			// The CustomID on the select menu encodes the resume point;
+			// the selected option's Value encodes the option's numeric ID.
+			customID := string(d.CustomID)
+			resumePointID, _, isResume := message.DecodeCustomIDMessageComponentResumePoint(customID)
+			if isResume {
+				resumePoint, err := a.env.ResumePointStore.ResumePoint(context.TODO(), resumePointID)
+				if err != nil {
+					if errors.Is(err, store.ErrNotFound) {
+						return
+					}
+
+					slog.Error(
+						"Failed to get resume point",
+						slog.String("resume_point_id", resumePointID),
+						slog.String("error", err.Error()),
+					)
+					return
+				}
+
+				if resumePoint.CommandID.Valid {
+					a.RLock()
+					defer a.RUnlock()
+
+					command, ok := a.commands[resumePoint.CommandID.String]
+					if !ok {
+						return
+					}
+
+					node := command.flow.FindChildWithID(resumePoint.FlowNodeID, true)
+					if node == nil {
+						slog.Error(
+							"Failed to find node in flow",
+							slog.String("resume_point_id", resumePointID),
+							slog.String("command_id", resumePoint.CommandID.String),
+						)
+						return
+					}
+
+					go a.env.executeFlowEvent(
+						context.Background(),
+						a.id,
+						node,
+						session,
+						event,
+						entityLinks{
+							CommandID: null.NewString(command.cmd.ID, true),
+						},
+						&resumePoint.FlowState,
+					)
+				}
+				return
+			}
+
+			// Not a resume point — route via MessageInstance (message template)
+			messageID := e.Message.ID.String()
+			messageInstance, err := a.env.MessageInstanceStore.MessageInstanceByDiscordMessageID(context.TODO(), messageID)
+			if err != nil {
+				if errors.Is(err, store.ErrNotFound) {
+					return
+				}
+				slog.With("error", err).Error("failed to get message instance for select menu")
+				return
+			}
+
+			instance, err := NewMessageInstance(
+				a.id,
+				messageInstance,
+				a.env,
+			)
+			if err != nil {
+				slog.With("error", err).Error("failed to create message instance for select menu")
+				return
+			}
+
+			go instance.HandleEvent(appID, session, event)
 		case *discord.ModalInteraction:
 			customID := string(d.CustomID)
 			resumePointID, ok := message.DecodeCustomIDModalResumePoint(customID)

--- a/kite-service/internal/core/engine/message.go
+++ b/kite-service/internal/core/engine/message.go
@@ -55,12 +55,19 @@ func (m *MessageInstance) HandleEvent(appID string, session *state.State, event 
 		return
 	}
 
-	d, ok := i.InteractionEvent.Data.(*discord.ButtonInteraction)
-	if !ok {
+	var flowSourceID string
+	switch d := i.InteractionEvent.Data.(type) {
+	case *discord.ButtonInteraction:
+		flowSourceID = string(d.CustomID)
+	case *discord.StringSelectInteraction:
+		if len(d.Values) == 0 {
+			return
+		}
+		// Value = option's flow_source_id (set at message build time)
+		flowSourceID = d.Values[0]
+	default:
 		return
 	}
-
-	flowSourceID := string(d.CustomID)
 
 	links := entityLinks{
 		MessageID:         null.NewString(m.msg.MessageID, true),

--- a/kite-service/pkg/message/convert.go
+++ b/kite-service/pkg/message/convert.go
@@ -1,6 +1,8 @@
 package message
 
 import (
+	"fmt"
+
 	"github.com/diamondburned/arikawa/v3/api"
 	"github.com/diamondburned/arikawa/v3/discord"
 	"github.com/diamondburned/arikawa/v3/utils/json/option"
@@ -122,10 +124,6 @@ func (f *EmbedFieldData) ToEmbedField() discord.EmbedField {
 		return discord.EmbedField{}
 	}
 
-	if f == nil {
-		return discord.EmbedField{}
-	}
-
 	return discord.EmbedField{
 		Name:   f.Name,
 		Value:  f.Value,
@@ -195,7 +193,7 @@ func (c *ComponentData) ToComponent(opts ConvertOptions) discord.InteractiveComp
 	}
 
 	switch c.Type {
-	case int(discord.ButtonComponentType):
+	case 2: // Button
 		var style discord.ButtonComponentStyle
 		switch c.Style {
 		case 2:
@@ -225,6 +223,37 @@ func (c *ComponentData) ToComponent(opts ConvertOptions) discord.InteractiveComp
 			Emoji:    c.Emoji.ToEmoji(),
 			Disabled: c.Disabled,
 			CustomID: customID,
+		}
+
+	case 3: // String Select Menu
+		var customID discord.ComponentID
+		if opts.ComponentIDFactory != nil {
+			customID = opts.ComponentIDFactory(c)
+		} else {
+			customID = discord.ComponentID(c.FlowSourceID)
+		}
+
+		options := make([]discord.SelectOption, len(c.Options))
+		for i, opt := range c.Options {
+			// Value = flow_source_id: works for both message template routing
+			// (direct map lookup) and command flow routing (handle by flow_source_id).
+			value := opt.FlowSourceID
+			if value == "" {
+				value = fmt.Sprintf("option_%d", i)
+			}
+			options[i] = discord.SelectOption{
+				Label:       opt.Label,
+				Value:       value,
+				Description: opt.Description,
+				Emoji:       opt.Emoji.ToEmoji(),
+				Default:     opt.Default,
+			}
+		}
+		return &discord.StringSelectComponent{
+			CustomID:    customID,
+			Placeholder: c.Placeholder,
+			Options:     options,
+			Disabled:    c.Disabled,
 		}
 	}
 

--- a/kite-web/src/components/flow/FlowNodeActionMessage.tsx
+++ b/kite-web/src/components/flow/FlowNodeActionMessage.tsx
@@ -1,8 +1,8 @@
 import { NodeProps } from "@/lib/flow/dataSchema";
 import { suspendColor } from "@/lib/flow/nodes";
-import { ComponentData } from "@/lib/types/message.gen";
+import { ComponentData, ComponentSelectOptionData } from "@/lib/types/message.gen";
 import { Position } from "@xyflow/react";
-import { MousePointerClickIcon } from "lucide-react";
+import { ChevronDownIcon, MousePointerClickIcon } from "lucide-react";
 import { buttonColors } from "../message/MessageComponentButton";
 import FlowNodeBase from "./FlowNodeBase";
 import FlowNodeHandle from "./FlowNodeHandle";
@@ -32,9 +32,13 @@ export default function FlowNodeActionMessage(props: NodeProps) {
       <div className="flex flex-col mt-2 gap-5">
         {components?.map((row) => (
           <div key={row.id} className="flex items-center justify-left gap-2">
-            {row.components?.map((comp) => (
-              <ButtonHandle comp={comp} key={comp.id} />
-            ))}
+            {row.components?.map((comp) =>
+              comp.type === 3 ? (
+                <SelectMenuOptions comp={comp} key={comp.id} />
+              ) : (
+                <ButtonHandle comp={comp} key={comp.id} />
+              )
+            )}
           </div>
         ))}
       </div>
@@ -65,14 +69,39 @@ function ButtonHandle({ comp }: { comp: ComponentData }) {
       <FlowNodeHandle
         type="source"
         position={Position.Bottom}
-        id={buttonHandleId(comp)}
+        id={`component_${comp.id}`}
         size="small"
       />
     </div>
   );
 }
 
-function buttonHandleId(comp: ComponentData) {
-  // NOTE: The format has to match with the backend for the resume point to work
-  return `component_${comp.id}`;
+function SelectMenuOptions({ comp }: { comp: ComponentData }) {
+  if (!comp.options?.length) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {comp.options.map((opt) => (
+        <SelectOptionHandle key={opt.id} opt={opt} />
+      ))}
+    </div>
+  );
+}
+
+function SelectOptionHandle({ opt }: { opt: ComponentSelectOptionData }) {
+  return (
+    <div className="relative">
+      <div className="px-2 shadow-md rounded-md relative max-w-40 min-w-16 text-center h-8 flex items-center justify-center text-white gap-2 bg-[#4E5058]">
+        <ChevronDownIcon className="w-4 h-4 flex-none" />
+        <div className="text-sm truncate">{opt.label || "Option"}</div>
+      </div>
+
+      <FlowNodeHandle
+        type="source"
+        position={Position.Bottom}
+        id={`component_${opt.flow_source_id || opt.id}`}
+        size="small"
+      />
+    </div>
+  );
 }

--- a/kite-web/src/components/message/MessageComponentRow.tsx
+++ b/kite-web/src/components/message/MessageComponentRow.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "../ui/button";
 import { getUniqueId } from "@/lib/utils";
 import MessageComponentButton from "./MessageComponentButton";
+import MessageComponentSelectMenu from "./MessageComponentSelectMenu";
 
 export default function MessageComponentRow({
   rowIndex,
@@ -27,9 +28,10 @@ export default function MessageComponentRow({
       state.components[rowIndex].components.map((c) => c.id)
     )
   );
-  const isButtonRow = useCurrentMessage((state) =>
-    state.components[rowIndex].components.every((c) => c.type === 2)
+  const isSelectMenuRow = useCurrentMessage((state) =>
+    state.components[rowIndex].components.some((c) => c.type === 3)
   );
+
   const [moveUp, moveDown, duplicate, remove] = useCurrentMessage(
     useShallow((state) => [
       state.moveComponentRowUp,
@@ -43,10 +45,14 @@ export default function MessageComponentRow({
     useShallow((state) => [state.addButton, state.clearButtons])
   );
 
+  const rowLabel = isSelectMenuRow
+    ? `Row ${rowIndex + 1} — Select Menu`
+    : `Row ${rowIndex + 1}`;
+
   return (
     <Card className="px-4 py-3">
       <MessageCollapsibleSection
-        title={`Row ${rowIndex + 1}`}
+        title={rowLabel}
         size="lg"
         valiationPathPrefix={`components.${rowIndex}`}
         actions={
@@ -81,22 +87,29 @@ export default function MessageComponentRow({
         }
         className="space-y-3"
       >
-        {isButtonRow ? (
+        {isSelectMenuRow ? (
           <>
-            {components.map((id, i) =>
-              isButtonRow ? (
-                <MessageComponentButton
-                  key={id}
-                  rowIndex={rowIndex}
-                  rowId={rowId}
-                  compIndex={i}
-                  compId={id}
-                  disableFlowEditor={disableFlowEditor}
-                ></MessageComponentButton>
-              ) : (
-                <div key={id}></div>
-              )
-            )}
+            {components.map((id, i) => (
+              <MessageComponentSelectMenu
+                key={id}
+                rowIndex={rowIndex}
+                compIndex={i}
+                compCount={components.length}
+              />
+            ))}
+          </>
+        ) : (
+          <>
+            {components.map((id, i) => (
+              <MessageComponentButton
+                key={id}
+                rowIndex={rowIndex}
+                rowId={rowId}
+                compIndex={i}
+                compId={id}
+                disableFlowEditor={disableFlowEditor}
+              />
+            ))}
             <div className="space-x-3">
               <Button
                 onClick={() =>
@@ -105,7 +118,7 @@ export default function MessageComponentRow({
                     type: 2,
                     style: 2,
                     label: "",
-                    flow_source_id: getUniqueId().toString(), // TODO: refactor this for flow_source_id
+                    flow_source_id: getUniqueId().toString(),
                   })
                 }
                 size="sm"
@@ -122,10 +135,6 @@ export default function MessageComponentRow({
               </Button>
             </div>
           </>
-        ) : (
-          <div className="text-muted-foreground">
-            select menus aren&apos;t supported yet
-          </div>
         )}
       </MessageCollapsibleSection>
     </Card>

--- a/kite-web/src/components/message/MessageComponentSelectMenu.tsx
+++ b/kite-web/src/components/message/MessageComponentSelectMenu.tsx
@@ -1,0 +1,142 @@
+import { useCurrentFlow, useCurrentMessage } from "@/lib/message/state";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "../ui/card";
+import MessageCollapsibleSection from "./MessageCollapsibleSection";
+import MessageInput from "./MessageInput";
+import { Button } from "../ui/button";
+import { getUniqueId } from "@/lib/utils";
+import { useCallback } from "react";
+import MessageComponentSelectMenuOption from "./MessageComponentSelectMenuOption";
+
+export default function MessageComponentSelectMenu({
+  rowIndex,
+  compIndex,
+  compCount,
+  disableFlowEditor,
+}: {
+  rowIndex: number;
+  compIndex: number;
+  compCount: number;
+  disableFlowEditor?: boolean;
+}) {
+  const [placeholder, setPlaceholder] = useCurrentMessage(
+    useShallow((state) => [
+      state.getSelectMenu(rowIndex, compIndex)?.placeholder,
+      state.setSelectMenuPlaceholder,
+    ])
+  );
+
+  const [disabled, setDisabled] = useCurrentMessage(
+    useShallow((state) => [
+      state.getSelectMenu(rowIndex, compIndex)?.disabled,
+      state.setSelectMenuDisabled,
+    ])
+  );
+
+  const options = useCurrentMessage(
+    useShallow(
+      (state) =>
+        state.getSelectMenu(rowIndex, compIndex)?.options?.map((o) => o.id) ||
+        []
+    )
+  );
+
+  const [addOption, clearOptions] = useCurrentMessage(
+    useShallow((state) => [
+      state.addSelectMenuOption,
+      state.clearSelectMenuOptions,
+    ])
+  );
+
+  const replaceFlow = useCurrentFlow((s) => s.replaceFlow);
+
+
+  return (
+    <Card className="p-3 border-l-[3px] rounded-l-[5px] border-l-violet-500">
+      <MessageCollapsibleSection
+        title="Select Menu"
+        size="md"
+        valiationPathPrefix={`components.${rowIndex}.components.${compIndex}`}
+        className="space-y-3"
+        animate={false}
+        defaultOpen={true}
+      >
+        <div className="flex space-x-3">
+          <div className="w-full">
+            <MessageInput
+              type="text"
+              label="Placeholder"
+              maxLength={150}
+              value={placeholder || ""}
+              onChange={(v) =>
+                setPlaceholder(rowIndex, compIndex, v || undefined)
+              }
+              validationPath={`components.${rowIndex}.components.${compIndex}.placeholder`}
+              placeholders
+            />
+          </div>
+          <div className="flex-none">
+            <MessageInput
+              type="toggle"
+              label="Disabled"
+              value={disabled || false}
+              onChange={(v) =>
+                setDisabled(rowIndex, compIndex, v || undefined)
+              }
+              validationPath={`components.${rowIndex}.components.${compIndex}.disabled`}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="text-sm font-medium text-foreground/80">
+            Options ({options.length}/25) — connect each option in the flow editor
+          </div>
+          {options.map((id, k) => (
+            <MessageComponentSelectMenuOption
+              key={id}
+              rowIndex={rowIndex}
+              compIndex={compIndex}
+              optionIndex={k}
+              optionCount={options.length}
+            />
+          ))}
+          <div className="space-x-3">
+            <Button
+              onClick={() => {
+                const flowSourceId = getUniqueId().toString();
+                addOption(rowIndex, compIndex, {
+                  id: getUniqueId(),
+                  label: "",
+                  flow_source_id: flowSourceId,
+                });
+                replaceFlow(flowSourceId, {
+                  nodes: [{
+                    id: getUniqueId().toString(),
+                    position: { x: 0, y: 0 },
+                    data: {},
+                    type: "entry_component_button",
+                  }],
+                  edges: [],
+                });
+              }}
+              size="sm"
+              disabled={options.length >= 25}
+            >
+              Add Option
+            </Button>
+            {options.length > 0 && (
+              <Button
+                onClick={() => clearOptions(rowIndex, compIndex)}
+                variant="destructive"
+                size="sm"
+              >
+                Clear Options
+              </Button>
+            )}
+          </div>
+        </div>
+      </MessageCollapsibleSection>
+    </Card>
+  );
+}

--- a/kite-web/src/components/message/MessageComponentSelectMenuOption.tsx
+++ b/kite-web/src/components/message/MessageComponentSelectMenuOption.tsx
@@ -1,0 +1,178 @@
+import { useCurrentFlow, useCurrentMessage } from "@/lib/message/state";
+import { useShallow } from "zustand/react/shallow";
+import { Card } from "../ui/card";
+import MessageCollapsibleSection from "./MessageCollapsibleSection";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CopyIcon,
+  TrashIcon,
+} from "lucide-react";
+import MessageInput from "./MessageInput";
+import MessageEmojiPicker from "./MessageEmojiPicker";
+import FlowPreview from "../flow/FlowPreview";
+import FlowDialog from "../flow/FlowDialog";
+import { FlowData } from "@/lib/flow/dataSchema";
+import { useCallback, useRef } from "react";
+import { getUniqueId } from "@/lib/utils";
+
+function makeInitialFlow(): FlowData {
+  return {
+    nodes: [
+      {
+        id: getUniqueId().toString(),
+        position: { x: 0, y: 0 },
+        data: {},
+        type: "entry_component_button",
+      },
+    ],
+    edges: [],
+  };
+}
+
+export default function MessageComponentSelectMenuOption({
+  rowIndex,
+  compIndex,
+  optionIndex,
+  optionCount,
+  disableFlowEditor,
+}: {
+  rowIndex: number;
+  compIndex: number;
+  optionIndex: number;
+  optionCount: number;
+  disableFlowEditor?: boolean;
+}) {
+  const [label, setLabel] = useCurrentMessage(
+    useShallow((state) => [
+      state.getSelectMenu(rowIndex, compIndex)?.options?.[optionIndex]?.label || "",
+      state.setSelectMenuOptionLabel,
+    ])
+  );
+
+  const [description, setDescription] = useCurrentMessage(
+    useShallow((state) => [
+      state.getSelectMenu(rowIndex, compIndex)?.options?.[optionIndex]?.description,
+      state.setSelectMenuOptionDescription,
+    ])
+  );
+
+  const [emoji, setEmoji] = useCurrentMessage(
+    useShallow((state) => [
+      state.getSelectMenu(rowIndex, compIndex)?.options?.[optionIndex]?.emoji,
+      state.setSelectMenuOptionEmoji,
+    ])
+  );
+
+  const [moveUp, moveDown, duplicate, remove] = useCurrentMessage(
+    useShallow((state) => [
+      state.moveSelectMenuOptionUp,
+      state.moveSelectMenuOptionDown,
+      state.duplicateSelectMenuOption,
+      state.deleteSelectMenuOption,
+    ])
+  );
+
+  const flowSourceId = useCurrentMessage(
+    (state) =>
+      state.getSelectMenu(rowIndex, compIndex)?.options?.[optionIndex]?.flow_source_id
+  );
+
+  const [flowData, replaceFlow] = useCurrentFlow(
+    useShallow((s) => [s.getFlow(flowSourceId || ""), s.replaceFlow])
+  );
+
+  // Stable initial flow per option mount
+  const initialFlowRef = useRef<FlowData | null>(null);
+  if (!initialFlowRef.current) {
+    initialFlowRef.current = makeInitialFlow();
+  }
+
+  const onFlowDialogClose = useCallback(
+    (d: FlowData) => {
+      if (flowSourceId) {
+        replaceFlow(flowSourceId, d);
+      }
+    },
+    [replaceFlow, flowSourceId]
+  );
+
+  return (
+    <Card className="p-3 border-l-[3px] rounded-l-[5px] border-l-indigo-400">
+      <MessageCollapsibleSection
+        title={`Option ${optionIndex + 1}${label ? `: ${label}` : ""}`}
+        size="md"
+        valiationPathPrefix={`components.${rowIndex}.components.${compIndex}.options.${optionIndex}`}
+        className="space-y-3"
+        animate={false}
+        defaultOpen={false}
+        actions={
+          <>
+            {optionIndex > 0 && (
+              <ChevronUpIcon
+                className="h-5 w-5"
+                onClick={() => moveUp(rowIndex, compIndex, optionIndex)}
+                role="button"
+              />
+            )}
+            {optionIndex < optionCount - 1 && (
+              <ChevronDownIcon
+                className="h-5 w-5"
+                onClick={() => moveDown(rowIndex, compIndex, optionIndex)}
+                role="button"
+              />
+            )}
+            {optionCount < 25 && (
+              <CopyIcon
+                className="h-4 w-4"
+                onClick={() => duplicate(rowIndex, compIndex, optionIndex)}
+                role="button"
+              />
+            )}
+            <TrashIcon
+              className="h-4 w-4"
+              onClick={() => remove(rowIndex, compIndex, optionIndex)}
+              role="button"
+            />
+          </>
+        }
+      >
+        <div className="flex space-x-3">
+          <MessageEmojiPicker
+            emoji={emoji}
+            onChange={(v) => setEmoji(rowIndex, compIndex, optionIndex, v)}
+          />
+          <MessageInput
+            type="text"
+            label="Label"
+            maxLength={100}
+            value={label}
+            onChange={(v) => setLabel(rowIndex, compIndex, optionIndex, v)}
+            validationPath={`components.${rowIndex}.components.${compIndex}.options.${optionIndex}.label`}
+            placeholders
+          />
+        </div>
+        <MessageInput
+          type="text"
+          label="Description"
+          maxLength={100}
+          value={description || ""}
+          onChange={(v) =>
+            setDescription(rowIndex, compIndex, optionIndex, v || undefined)
+          }
+          validationPath={`components.${rowIndex}.components.${compIndex}.options.${optionIndex}.description`}
+          placeholders
+        />
+        {!disableFlowEditor && (
+          <FlowDialog
+            flowData={flowData || initialFlowRef.current}
+            context="component_button"
+            onClose={onFlowDialogClose}
+          >
+            <FlowPreview className="h-64 p-16 w-full" onClick={() => {}} />
+          </FlowDialog>
+        )}
+      </MessageCollapsibleSection>
+    </Card>
+  );
+}

--- a/kite-web/src/components/message/MessageComponentsSection.tsx
+++ b/kite-web/src/components/message/MessageComponentsSection.tsx
@@ -28,7 +28,7 @@ export default function MessageComponentsSection({
     });
   }, [components, addRow]);
 
-  /* const addSelectMenuRow = useCallback(() => {
+  const addSelectMenuRow = useCallback(() => {
     if (components.length >= 5) return;
     addRow({
       id: getUniqueId(),
@@ -38,10 +38,11 @@ export default function MessageComponentsSection({
           id: getUniqueId(),
           type: 3,
           options: [],
+          flow_source_id: getUniqueId().toString(),
         },
       ],
     });
-  }, [components, addRow]); */
+  }, [components, addRow]);
 
   return (
     <CollapsibleSection
@@ -58,7 +59,16 @@ export default function MessageComponentsSection({
         />
       ))}
       <div className="space-x-3">
-        <Button onClick={addButtonRow}>Add Button Row</Button>
+        <Button onClick={addButtonRow} disabled={components.length >= 5}>
+          Add Button Row
+        </Button>
+        <Button
+          onClick={addSelectMenuRow}
+          variant="outline"
+          disabled={components.length >= 5}
+        >
+          Add Select Menu Row
+        </Button>
         <Button onClick={clearComponents} variant="outline">
           Clear Components
         </Button>

--- a/kite-web/src/components/message/MessagePreview.tsx
+++ b/kite-web/src/components/message/MessagePreview.tsx
@@ -141,6 +141,33 @@ export default function MessagePreview({
                     >
                       {comp.label}
                     </DiscordButton>
+                  ) : comp.type === 3 ? (
+                    <select
+                      key={comp.id}
+                      disabled={comp.disabled}
+                      defaultValue=""
+                      style={{
+                        background: "var(--background-secondary, #2b2d31)",
+                        color: "var(--text-normal, #dbdee1)",
+                        border: "1px solid var(--background-tertiary, #1e1f22)",
+                        borderRadius: "4px",
+                        padding: "10px 32px 10px 12px",
+                        width: "100%",
+                        fontSize: "14px",
+                        cursor: comp.disabled ? "not-allowed" : "pointer",
+                        opacity: comp.disabled ? 0.5 : 1,
+                        appearance: "none",
+                      }}
+                    >
+                      <option value="" disabled>
+                        {comp.placeholder || "Make a selection"}
+                      </option>
+                      {comp.options?.map((opt, i) => (
+                        <option key={i} value={opt.label}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
                   ) : null
                 )}
               </DiscordActionRow>

--- a/kite-web/src/lib/message/schema.ts
+++ b/kite-web/src/lib/message/schema.ts
@@ -267,6 +267,7 @@ export const selectMenuOptionSchema = z.object({
   label: z.string().min(1).max(100),
   description: z.optional(z.string().min(1).max(100)),
   emoji: z.optional(emojiSchema),
+  flow_source_id: z.string().default(() => getUniqueId().toString()),
 });
 
 export type MessageComponentSelectMenuOption = z.infer<

--- a/kite-web/src/lib/message/schemaRestore.ts
+++ b/kite-web/src/lib/message/schemaRestore.ts
@@ -270,6 +270,10 @@ export const selectMenuOptionSchema = z.object({
   label: z.preprocess((d) => d ?? undefined, z.string().default("")),
   description: z.preprocess((d) => d || undefined, z.optional(z.string())),
   emoji: z.preprocess((d) => d ?? undefined, z.optional(emojiSchema)),
+  flow_source_id: z.preprocess(
+    (d) => d ?? undefined,
+    z.string().default(() => getUniqueId().toString())
+  ),
 });
 
 export type MessageComponentSelectMenuOption = z.infer<


### PR DESCRIPTION
I've added a way to have dropdowns with embeds and connect them with flows. It works the same way as buttons, but looks different and better. It works for both commands and message templates. 
 @merlinfuchs, please review.

Images of it working below:
<img width="890" height="469" alt="Screenshot 2026-05-06 210525" src="https://github.com/user-attachments/assets/3f2ea6e0-c3ff-43f0-a042-d66a13da92ef" />
<img width="1266" height="1137" alt="Screenshot 2026-05-04 063600" src="https://github.com/user-attachments/assets/602c45ab-dbcf-4de5-bb96-b31959fc0b0f" />
