### PR TITLE
perf: bound outbound connections and drop protocol events at the gateway

### DIFF
--- a/kite-service/internal/config/default.toml
+++ b/kite-service/internal/config/default.toml
@@ -26,7 +26,7 @@ populate_overlap = "5s"
 populate_interval = "10s"
 remove_dangling_interval = "60s"
 populate_overlap = "5s"
-start_interval = "10ms"
+start_interval = "100ms"
 
 [http]
 max_idle_conns = 512

--- a/kite-service/internal/config/default.toml
+++ b/kite-service/internal/config/default.toml
@@ -31,6 +31,7 @@ start_interval = "10ms"
 [http]
 max_idle_conns = 512
 max_idle_conns_per_host = 128
+max_conns_per_host = 256
 
 [debug]
 enabled = false

--- a/kite-service/internal/config/model.go
+++ b/kite-service/internal/config/model.go
@@ -135,6 +135,11 @@ type GatewayConfig struct {
 type HTTPConfig struct {
 	MaxIdleConns        int `toml:"max_idle_conns"`
 	MaxIdleConnsPerHost int `toml:"max_idle_conns_per_host"`
+	// MaxConnsPerHost bounds concurrent connections to a single host. Go
+	// leaves this unlimited, so a burst opens one socket per in-flight
+	// request; bounding it makes requests queue locally instead of arriving
+	// as a connection flood.
+	MaxConnsPerHost int `toml:"max_conns_per_host"`
 }
 
 // DebugConfig controls the debug server, which exposes pprof profiles and

--- a/kite-service/internal/core/gateway/events_test.go
+++ b/kite-service/internal/core/gateway/events_test.go
@@ -1,0 +1,73 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/diamondburned/arikawa/v3/gateway"
+	"github.com/diamondburned/arikawa/v3/utils/ws"
+	"github.com/kitecloud/kite/kite-service/internal/model"
+)
+
+// Protocol frames report an empty event type. The dispatch path can never
+// match one, so they are dropped at the gateway handler -- but only because
+// nothing downstream uses an empty type as a real key. These tests pin that
+// assumption, since it is what makes the filter safe.
+
+func TestProtocolEventsReportEmptyEventType(t *testing.T) {
+	// A representative sample of arikawa's protocol frames. If a future
+	// version gives one of these a real event type the filter simply stops
+	// dropping it, which is harmless. The dangerous direction is the reverse,
+	// covered below.
+	protocol := []ws.Event{
+		&gateway.HeartbeatAckEvent{},
+		&gateway.HelloEvent{},
+		&gateway.ReconnectEvent{},
+		func() *gateway.InvalidSessionEvent { e := gateway.InvalidSessionEvent(false); return &e }(),
+	}
+
+	for _, e := range protocol {
+		if got := e.EventType(); got != "" {
+			t.Errorf("%T reports event type %q, expected empty", e, got)
+		}
+	}
+}
+
+// The filter is only safe if no event the engine acts on carries an empty
+// type. If one ever does, it would be silently swallowed at the gateway.
+func TestDispatchedEventsHaveNonEmptyEventType(t *testing.T) {
+	dispatched := []ws.Event{
+		&gateway.MessageCreateEvent{},
+		&gateway.MessageUpdateEvent{},
+		&gateway.MessageDeleteEvent{},
+		&gateway.GuildMemberAddEvent{},
+		&gateway.GuildMemberRemoveEvent{},
+		&gateway.MessageReactionAddEvent{},
+		&gateway.InteractionCreateEvent{},
+		&gateway.GuildCreateEvent{},
+		&gateway.ReadyEvent{},
+	}
+
+	for _, e := range dispatched {
+		if e.EventType() == "" {
+			t.Errorf("%T reports an empty event type and would be filtered out", e)
+		}
+	}
+}
+
+// No event listener type may be empty, or the filter would drop events that
+// listener was registered for.
+func TestNoEventListenerTypeIsEmpty(t *testing.T) {
+	types := []model.EventListenerType{
+		model.EventListenerTypeDiscordMessageCreate,
+		model.EventListenerTypeDiscordMessageUpdate,
+		model.EventListenerTypeDiscordMessageDelete,
+		model.EventListenerTypeDiscordGuildMemberAdd,
+		model.EventListenerTypeDiscordGuildMemberRemove,
+	}
+
+	for _, tp := range types {
+		if tp == "" {
+			t.Error("an event listener type is empty, which the protocol filter would swallow")
+		}
+	}
+}

--- a/kite-service/internal/core/gateway/gateway.go
+++ b/kite-service/internal/core/gateway/gateway.go
@@ -102,7 +102,19 @@ func (g *Gateway) startGateway() {
 	)
 
 	g.session.AddHandler(func(e gateway.Event) {
-		metrics.GatewayEvents.Add(string(e.EventType()), 1)
+		// Protocol frames -- heartbeat acks, hello, reconnect, invalid session
+		// -- report an empty event type. Nothing downstream can ever match
+		// them: no event listener type and no plugin event type is empty. At
+		// steady state they are the single largest source of events, roughly
+		// one heartbeat per connection every 41s, so dropping them here keeps
+		// them off the dispatch path entirely and stops them dominating both
+		// the event counter and the dropped-event counter.
+		eventType := e.EventType()
+		if eventType == "" {
+			return
+		}
+
+		metrics.GatewayEvents.Add(string(eventType), 1)
 		g.eventHandler.HandleEvent(g.app.ID, g.session, e)
 	})
 

--- a/kite-service/internal/core/gateway/manager.go
+++ b/kite-service/internal/core/gateway/manager.go
@@ -32,10 +32,17 @@ type GatewayManagerConfig struct {
 	StartInterval          time.Duration
 }
 
-// defaultStartInterval paces gateway starts when none is configured. The
-// previous hardcoded value was 100ms, which at tens of thousands of apps meant
-// a cold start took hours to finish connecting.
-const defaultStartInterval = 10 * time.Millisecond
+// defaultStartInterval paces gateway starts when none is configured.
+//
+// This bounds the rate of new TLS handshakes, not anything Discord enforces:
+// each app has its own bot token and so its own identify budget. Each cluster
+// paces through its own share of apps independently, so the fleet-wide rate is
+// this multiplied by the cluster count.
+//
+// Tune via gateway.start_interval. The trade is cold-start time against
+// outbound connection rate: at ~9k apps per cluster, 100ms means roughly 15
+// minutes to initiate them all, 10ms means about 90 seconds.
+const defaultStartInterval = 100 * time.Millisecond
 
 type GatewayManager struct {
 	sync.Mutex

--- a/kite-service/internal/entry/server/helpers.go
+++ b/kite-service/internal/entry/server/helpers.go
@@ -68,10 +68,22 @@ func configureHTTPTransport(cfg *config.Config) {
 		transport.MaxIdleConnsPerHost = cfg.HTTP.MaxIdleConnsPerHost
 	}
 
+	// Go leaves MaxConnsPerHost unlimited, which means a burst of concurrent
+	// requests opens one socket each. On a cold start that produced thousands
+	// of simultaneous connections to a single host, which upstream served at a
+	// few requests per second -- almost certainly throttling what looks like a
+	// connection flood. Bounding it makes the requests queue locally and go
+	// out at a sane rate instead, which is both faster end to end and far less
+	// hostile to whatever is on the other side.
+	if cfg.HTTP.MaxConnsPerHost > 0 {
+		transport.MaxConnsPerHost = cfg.HTTP.MaxConnsPerHost
+	}
+
 	slog.Info(
 		"Configured HTTP connection pool",
 		slog.Int("max_idle_conns", transport.MaxIdleConns),
 		slog.Int("max_idle_conns_per_host", transport.MaxIdleConnsPerHost),
+		slog.Int("max_conns_per_host", transport.MaxConnsPerHost),
 	)
 }
 


### PR DESCRIPTION
Two findings from profiling the first deploy of #320.

## Startup was gated on one REST call, via connection concurrency

Goroutine profile from one cluster, ~4 minutes after start:

| | |
|---|---|
| Registered gateways | 9,059 |
| Blocked in `CurrentApplication` → `computeIntents` → `startGateway` | **6,338** |
| Connected (WS spin loop) | 2,719 |

Every gateway that had not connected was parked in `net/http.(*persistConn).roundTrip`. `READY` was arriving at ~307/min, projecting ~35–40 minutes to fully connect.

The count is not the problem — 9k HTTP requests should take seconds. The problem is that `http.Transport.MaxConnsPerHost` defaults to unlimited, so each in-flight request opened its own socket and we hit a single host with 6,338 simultaneous connections. Upstream served that at roughly 5/sec, which is not Discord's documented behaviour (the 50 req/s global limit is *per token*, and these are 9,000 distinct tokens) and looks like throttling of what resembles a connection flood.

**Correction — the connection bound is not the root cause.** It is nirn-proxy, which is used in production.

`QueueManager.getOrCreateBotQueue` takes a global write lock and holds it across the whole of `NewRequestQueue`:

```go
m.Lock()
defer m.Unlock()          // held across the whole creation
q, err = NewRequestQueue(ProcessRequest, token, m.bufferSize)
```

and `NewRequestQueue` makes two blocking upstream Discord calls, `GetBotUser(token)` and `GetBotGlobalLimit(token, user)`. Every one of our tokens is unseen on a cold start, so queue creation for all 9,059 serialises behind one mutex at roughly two Discord round trips each.

9,059 × ~200ms = **~30 minutes**, against a measured 5.1 connections/sec and a 35–40 minute projection. That accounts for the whole gap.

The bound to 256 (configurable via `[http] max_conns_per_host`) is kept because opening 6,338 simultaneous sockets at a proxy whose per-queue `BUFFER_SIZE` defaults to 50 is bad behaviour regardless — but it will **not** materially speed up startup on its own. The fix for that is to stop making the call, see below.

Worth checking separately whether `discord.proxy_url` is set in production — if REST goes through nirn-proxy then that is the upstream being flooded, and note `patchDiscordProxyURL` also sets `httputil.Retries = 10`, which would multiply any timeout.

## Protocol frames were 62% of all events

`HeartbeatAckEvent`, `HelloEvent`, `ReconnectEvent` and `InvalidSessionEvent` all return `""` from `EventType()`. Measured on the deployed cluster they were the single largest bucket — 8,274 in a 90s window against 570 `GUILD_CREATE` — roughly one heartbeat per connection every 41s.

Nothing downstream can ever match them, but they were traversing the entire dispatch path: metric increment, `EventHandlerWrapper` switch, `Engine.HandleEvent` (RLock + map lookup), `App.HandleEvent`, `dispatchEventToPlugins` (RLock + iterate every plugin), type switch, index lookup. At full connection that is ~390/sec per cluster, ~1,560/sec fleet-wide.

They now stop at the gateway handler. This also fixes two instrumentation problems from #320: `gateway_events_total` had its largest bucket under an empty key, and `gateway_events_dropped_total{unknown_app}` was dominated by heartbeats for apps with no engine entities rather than by genuinely dropped events.

Tests pin the assumption that makes the filter safe: protocol frames report an empty type, events the engine acts on never do, and no event listener type is empty.

## Not included

Caching `discord_flags` on the app row removes the `CurrentApplication` call from the connect path entirely. Given the nirn-proxy finding above this is now the actual fix for startup, not an optimisation: with flags cached a gateway start makes **zero** REST calls, so there is no queue-creation storm at all. Queue creation then happens lazily, spread over time, as flows actually run.

It needs a migration and a staleness decision (a cached `flags=0` would deny `MESSAGE_CONTENT` to someone who enabled it later), so it is left separate.

Worth considering separately: nirn-proxy exists to coordinate per-bot rate limits across processes. Kite shards apps across clusters by `CluserForKey`, so a given app's gateway traffic is already handled by exactly one process — there is little cross-process contention for the proxy to coordinate. Meanwhile its per-token queue creation costs a global lock plus two Discord calls, and bot queues are never evicted (only bearer queues use an LRU), so it holds a `RequestQueue` and a sweep goroutine per token indefinitely. That is a poor fit for 36,711 low-volume bots.
