### PR TITLE
perf: build the dangling-sweep lookup set once, not once per app

### DIFF
--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -115,12 +115,11 @@ func (a *App) AddPluginInstance(pluginInstance *model.PluginInstance) {
 	}
 }
 
-func (a *App) RemoveDanglingPluginInstances(pluginInstanceIDs []string) {
-	pluginInstanceIDMap := make(map[string]struct{}, len(pluginInstanceIDs))
-	for _, pluginInstanceID := range pluginInstanceIDs {
-		pluginInstanceIDMap[pluginInstanceID] = struct{}{}
-	}
-
+// RemoveDanglingPluginInstances drops instances whose row no longer exists.
+//
+// The caller owns the lookup set: it is identical for every app, so building
+// it here would rebuild the whole system's ID set once per app.
+func (a *App) RemoveDanglingPluginInstances(pluginInstanceIDMap map[string]struct{}) {
 	a.Lock()
 	defer a.Unlock()
 
@@ -158,12 +157,9 @@ func (a *App) AddCommand(commandID string, command *Command) {
 	a.rebuildCommandIndex()
 }
 
-func (a *App) RemoveDanglingCommands(commandIDs []string) {
-	commandIDMap := make(map[string]struct{}, len(commandIDs))
-	for _, commandID := range commandIDs {
-		commandIDMap[commandID] = struct{}{}
-	}
-
+// RemoveDanglingCommands drops commands whose row no longer exists. See
+// RemoveDanglingPluginInstances on why the caller owns the lookup set.
+func (a *App) RemoveDanglingCommands(commandIDMap map[string]struct{}) {
 	a.Lock()
 	defer a.Unlock()
 
@@ -190,12 +186,9 @@ func (a *App) AddEventListener(listenerID string, listener *EventListener) {
 	a.rebuildListenerIndex()
 }
 
-func (a *App) RemoveDanglingEventListeners(listenerIDs []string) {
-	listenerIDMap := make(map[string]struct{}, len(listenerIDs))
-	for _, listenerID := range listenerIDs {
-		listenerIDMap[listenerID] = struct{}{}
-	}
-
+// RemoveDanglingEventListeners drops listeners whose row no longer exists. See
+// RemoveDanglingPluginInstances on why the caller owns the lookup set.
+func (a *App) RemoveDanglingEventListeners(listenerIDMap map[string]struct{}) {
 	a.Lock()
 	defer a.Unlock()
 

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -115,16 +115,14 @@ func (a *App) AddPluginInstance(pluginInstance *model.PluginInstance) {
 	}
 }
 
-// RemoveDanglingPluginInstances drops instances whose row no longer exists.
-//
-// The caller owns the lookup set: it is identical for every app, so building
-// it here would rebuild the whole system's ID set once per app.
-func (a *App) RemoveDanglingPluginInstances(pluginInstanceIDMap map[string]struct{}) {
+// RemoveDanglingPluginInstances drops instances absent from enabledIDs, the
+// set of plugin instances that still exist and are enabled.
+func (a *App) RemoveDanglingPluginInstances(enabledIDs map[string]struct{}) {
 	a.Lock()
 	defer a.Unlock()
 
 	for pluginInstanceID, pluginInstance := range a.pluginInstances {
-		if _, ok := pluginInstanceIDMap[pluginInstanceID]; !ok {
+		if _, ok := enabledIDs[pluginInstanceID]; !ok {
 			err := pluginInstance.Close()
 			if err != nil {
 				slog.With("error", err).Error("failed to close plugin instance")
@@ -157,15 +155,15 @@ func (a *App) AddCommand(commandID string, command *Command) {
 	a.rebuildCommandIndex()
 }
 
-// RemoveDanglingCommands drops commands whose row no longer exists. See
-// RemoveDanglingPluginInstances on why the caller owns the lookup set.
-func (a *App) RemoveDanglingCommands(commandIDMap map[string]struct{}) {
+// RemoveDanglingCommands drops commands absent from enabledIDs, the set of
+// commands that still exist and are enabled.
+func (a *App) RemoveDanglingCommands(enabledIDs map[string]struct{}) {
 	a.Lock()
 	defer a.Unlock()
 
 	var removed bool
 	for cmdID := range a.commands {
-		if _, ok := commandIDMap[cmdID]; !ok {
+		if _, ok := enabledIDs[cmdID]; !ok {
 			delete(a.commands, cmdID)
 			removed = true
 		}
@@ -186,15 +184,15 @@ func (a *App) AddEventListener(listenerID string, listener *EventListener) {
 	a.rebuildListenerIndex()
 }
 
-// RemoveDanglingEventListeners drops listeners whose row no longer exists. See
-// RemoveDanglingPluginInstances on why the caller owns the lookup set.
-func (a *App) RemoveDanglingEventListeners(listenerIDMap map[string]struct{}) {
+// RemoveDanglingEventListeners drops listeners absent from enabledIDs, the set
+// of listeners that still exist and are enabled.
+func (a *App) RemoveDanglingEventListeners(enabledIDs map[string]struct{}) {
 	a.Lock()
 	defer a.Unlock()
 
 	var removed bool
 	for listenerID := range a.listeners {
-		if _, ok := listenerIDMap[listenerID]; !ok {
+		if _, ok := enabledIDs[listenerID]; !ok {
 			delete(a.listeners, listenerID)
 			removed = true
 		}

--- a/kite-service/internal/core/engine/app_test.go
+++ b/kite-service/internal/core/engine/app_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kitecloud/kite/kite-service/internal/model"
+	"github.com/kitecloud/kite/kite-service/internal/util"
 )
 
 // The command and listener lookup indexes replaced linear scans over every
@@ -61,7 +62,7 @@ func TestCommandIndexRebuiltOnRemoval(t *testing.T) {
 	app.AddCommand(testCommand("cmd-1", "keep"))
 	app.AddCommand(testCommand("cmd-2", "drop"))
 
-	app.RemoveDanglingCommands(idLookupSet([]string{"cmd-1"}))
+	app.RemoveDanglingCommands(util.IDSet([]string{"cmd-1"}))
 
 	if got := app.commandsByName["drop"]; got != nil {
 		t.Error("removed command still resolves by name")
@@ -120,7 +121,7 @@ func TestListenerIndexRebuiltOnRemoval(t *testing.T) {
 	app.AddEventListener(testListener("l-1", model.EventSourceDiscord, model.EventListenerTypeDiscordMessageCreate))
 	app.AddEventListener(testListener("l-2", model.EventSourceDiscord, model.EventListenerTypeDiscordMessageCreate))
 
-	app.RemoveDanglingEventListeners(idLookupSet([]string{"l-1"}))
+	app.RemoveDanglingEventListeners(util.IDSet([]string{"l-1"}))
 
 	if got := len(app.listenersByType[model.EventListenerTypeDiscordMessageCreate]); got != 1 {
 		t.Errorf("message_create listeners = %d, want 1 after removal", got)

--- a/kite-service/internal/core/engine/app_test.go
+++ b/kite-service/internal/core/engine/app_test.go
@@ -61,7 +61,7 @@ func TestCommandIndexRebuiltOnRemoval(t *testing.T) {
 	app.AddCommand(testCommand("cmd-1", "keep"))
 	app.AddCommand(testCommand("cmd-2", "drop"))
 
-	app.RemoveDanglingCommands([]string{"cmd-1"})
+	app.RemoveDanglingCommands(idLookupSet([]string{"cmd-1"}))
 
 	if got := app.commandsByName["drop"]; got != nil {
 		t.Error("removed command still resolves by name")
@@ -120,7 +120,7 @@ func TestListenerIndexRebuiltOnRemoval(t *testing.T) {
 	app.AddEventListener(testListener("l-1", model.EventSourceDiscord, model.EventListenerTypeDiscordMessageCreate))
 	app.AddEventListener(testListener("l-2", model.EventSourceDiscord, model.EventListenerTypeDiscordMessageCreate))
 
-	app.RemoveDanglingEventListeners([]string{"l-1"})
+	app.RemoveDanglingEventListeners(idLookupSet([]string{"l-1"}))
 
 	if got := len(app.listenersByType[model.EventListenerTypeDiscordMessageCreate]); got != 1 {
 		t.Errorf("message_create listeners = %d, want 1 after removal", got)

--- a/kite-service/internal/core/engine/engine.go
+++ b/kite-service/internal/core/engine/engine.go
@@ -105,20 +105,6 @@ func (e *Engine) populate(ctx context.Context) {
 	e.lastUpdate = tickStart.Add(-e.env.Config.PopulateOverlap)
 }
 
-// idLookupSet builds the membership set the dangling sweeps test against.
-//
-// It is built once per sweep rather than once per app. The set covers every
-// enabled entity in the system, so building it inside the per-app call made
-// the sweep cost O(apps x entities): with thousands of apps it dominated the
-// process's entire CPU usage and allocated a fresh system-wide map each time.
-func idLookupSet(ids []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(ids))
-	for _, id := range ids {
-		set[id] = struct{}{}
-	}
-	return set
-}
-
 func (e *Engine) removeDangling(ctx context.Context) {
 	if err := e.removeDanglingPlugins(ctx); err != nil {
 		slog.Error(
@@ -199,7 +185,7 @@ func (e *Engine) removeDanglingPlugins(ctx context.Context) error {
 		return fmt.Errorf("failed to get enabled plugin instance IDs: %w", err)
 	}
 
-	idSet := idLookupSet(pluginInstanceIDs)
+	idSet := util.IDSet(pluginInstanceIDs)
 
 	e.RLock()
 	defer e.RUnlock()
@@ -244,7 +230,7 @@ func (e *Engine) removeDanglingCommands(ctx context.Context) error {
 		return fmt.Errorf("failed to get enabled command IDs: %w", err)
 	}
 
-	idSet := idLookupSet(commandIDs)
+	idSet := util.IDSet(commandIDs)
 
 	e.RLock()
 	defer e.RUnlock()
@@ -287,7 +273,7 @@ func (e *Engine) removeDanglingEventListeners(ctx context.Context) error {
 		return fmt.Errorf("failed to get enabled event listener IDs: %w", err)
 	}
 
-	idSet := idLookupSet(listenerIDs)
+	idSet := util.IDSet(listenerIDs)
 
 	e.RLock()
 	defer e.RUnlock()

--- a/kite-service/internal/core/engine/engine.go
+++ b/kite-service/internal/core/engine/engine.go
@@ -105,6 +105,20 @@ func (e *Engine) populate(ctx context.Context) {
 	e.lastUpdate = tickStart.Add(-e.env.Config.PopulateOverlap)
 }
 
+// idLookupSet builds the membership set the dangling sweeps test against.
+//
+// It is built once per sweep rather than once per app. The set covers every
+// enabled entity in the system, so building it inside the per-app call made
+// the sweep cost O(apps x entities): with thousands of apps it dominated the
+// process's entire CPU usage and allocated a fresh system-wide map each time.
+func idLookupSet(ids []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set
+}
+
 func (e *Engine) removeDangling(ctx context.Context) {
 	if err := e.removeDanglingPlugins(ctx); err != nil {
 		slog.Error(
@@ -185,11 +199,13 @@ func (e *Engine) removeDanglingPlugins(ctx context.Context) error {
 		return fmt.Errorf("failed to get enabled plugin instance IDs: %w", err)
 	}
 
+	idSet := idLookupSet(pluginInstanceIDs)
+
 	e.RLock()
 	defer e.RUnlock()
 
 	for _, app := range e.apps {
-		app.RemoveDanglingPluginInstances(pluginInstanceIDs)
+		app.RemoveDanglingPluginInstances(idSet)
 	}
 
 	return nil
@@ -228,11 +244,13 @@ func (e *Engine) removeDanglingCommands(ctx context.Context) error {
 		return fmt.Errorf("failed to get enabled command IDs: %w", err)
 	}
 
+	idSet := idLookupSet(commandIDs)
+
 	e.RLock()
 	defer e.RUnlock()
 
 	for _, app := range e.apps {
-		app.RemoveDanglingCommands(commandIDs)
+		app.RemoveDanglingCommands(idSet)
 	}
 
 	return nil
@@ -269,11 +287,13 @@ func (e *Engine) removeDanglingEventListeners(ctx context.Context) error {
 		return fmt.Errorf("failed to get enabled event listener IDs: %w", err)
 	}
 
+	idSet := idLookupSet(listenerIDs)
+
 	e.RLock()
 	defer e.RUnlock()
 
 	for _, app := range e.apps {
-		app.RemoveDanglingEventListeners(listenerIDs)
+		app.RemoveDanglingEventListeners(idSet)
 	}
 
 	return nil

--- a/kite-service/internal/core/engine/engine_test.go
+++ b/kite-service/internal/core/engine/engine_test.go
@@ -129,3 +129,70 @@ func TestPopulatePartialFailureDoesNotAdvanceCursor(t *testing.T) {
 		t.Errorf("cursor advanced to %v despite one of three queries failing", e.lastUpdate)
 	}
 }
+
+func TestIDLookupSet(t *testing.T) {
+	set := idLookupSet([]string{"a", "b", "a"})
+
+	if len(set) != 2 {
+		t.Errorf("idLookupSet produced %d entries, want 2 after dedup", len(set))
+	}
+	for _, want := range []string{"a", "b"} {
+		if _, ok := set[want]; !ok {
+			t.Errorf("idLookupSet is missing %q", want)
+		}
+	}
+	if _, ok := set["c"]; ok {
+		t.Error("idLookupSet contains an id that was not passed in")
+	}
+}
+
+func TestIDLookupSetEmpty(t *testing.T) {
+	// A sweep that finds no enabled entities must still produce a usable set,
+	// so the per-app calls remove everything rather than panicking.
+	set := idLookupSet(nil)
+	if set == nil {
+		t.Fatal("idLookupSet(nil) returned a nil map")
+	}
+	if len(set) != 0 {
+		t.Errorf("idLookupSet(nil) produced %d entries, want 0", len(set))
+	}
+}
+
+// Reproduces the production shape of a dangling sweep: many apps in the
+// registry, all tested against the system-wide set of enabled entities.
+//
+// The set is now built once per sweep. Building it per app (the previous
+// behaviour) made the sweep O(apps x entities) and, at ~5k apps against a
+// system-wide set, accounted for 74% of the process's CPU.
+func benchmarkSweep(b *testing.B, apps, systemEntities int, perApp bool) {
+	ids := make([]string, systemEntities)
+	for i := range ids {
+		ids[i] = "cmd-" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/676)%26))
+	}
+
+	registry := make([]*App, apps)
+	for i := range registry {
+		app := NewApp("app", Env{})
+		app.AddCommand(testCommand(ids[i%len(ids)], "name"))
+		registry[i] = app
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		if perApp {
+			// Old shape: every app rebuilds the system-wide set.
+			for _, app := range registry {
+				app.RemoveDanglingCommands(idLookupSet(ids))
+			}
+		} else {
+			// Current shape: built once, shared by every app.
+			set := idLookupSet(ids)
+			for _, app := range registry {
+				app.RemoveDanglingCommands(set)
+			}
+		}
+	}
+}
+
+func BenchmarkSweepSetPerApp(b *testing.B) { benchmarkSweep(b, 500, 5000, true) }
+func BenchmarkSweepSetShared(b *testing.B) { benchmarkSweep(b, 500, 5000, false) }

--- a/kite-service/internal/core/engine/engine_test.go
+++ b/kite-service/internal/core/engine/engine_test.go
@@ -3,11 +3,13 @@ package engine
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/kitecloud/kite/kite-service/internal/model"
 	"github.com/kitecloud/kite/kite-service/internal/store"
+	"github.com/kitecloud/kite/kite-service/internal/util"
 )
 
 // The fakes embed their store interface so any method the engine does not call
@@ -130,69 +132,35 @@ func TestPopulatePartialFailureDoesNotAdvanceCursor(t *testing.T) {
 	}
 }
 
-func TestIDLookupSet(t *testing.T) {
-	set := idLookupSet([]string{"a", "b", "a"})
-
-	if len(set) != 2 {
-		t.Errorf("idLookupSet produced %d entries, want 2 after dedup", len(set))
-	}
-	for _, want := range []string{"a", "b"} {
-		if _, ok := set[want]; !ok {
-			t.Errorf("idLookupSet is missing %q", want)
-		}
-	}
-	if _, ok := set["c"]; ok {
-		t.Error("idLookupSet contains an id that was not passed in")
-	}
-}
-
-func TestIDLookupSetEmpty(t *testing.T) {
-	// A sweep that finds no enabled entities must still produce a usable set,
-	// so the per-app calls remove everything rather than panicking.
-	set := idLookupSet(nil)
-	if set == nil {
-		t.Fatal("idLookupSet(nil) returned a nil map")
-	}
-	if len(set) != 0 {
-		t.Errorf("idLookupSet(nil) produced %d entries, want 0", len(set))
-	}
-}
-
-// Reproduces the production shape of a dangling sweep: many apps in the
-// registry, all tested against the system-wide set of enabled entities.
+// Reproduces a dangling sweep at production shape: many apps in the registry,
+// each tested against the system-wide set of enabled entities. Measures the
+// steady state where nothing is dangling, which is the common case.
 //
-// The set is now built once per sweep. Building it per app (the previous
-// behaviour) made the sweep O(apps x entities) and, at ~5k apps against a
-// system-wide set, accounted for 74% of the process's CPU.
-func benchmarkSweep(b *testing.B, apps, systemEntities int, perApp bool) {
-	ids := make([]string, systemEntities)
-	for i := range ids {
-		ids[i] = "cmd-" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/676)%26))
+// The set is built once per sweep. Building it per app -- the previous
+// behaviour -- made this O(apps x entities) and accounted for 74% of the
+// process's CPU in production.
+func BenchmarkDanglingSweep(b *testing.B) {
+	const (
+		apps           = 500
+		systemEntities = 5000
+	)
+
+	enabledIDs := make([]string, systemEntities)
+	for i := range enabledIDs {
+		enabledIDs[i] = "cmd-" + strconv.Itoa(i)
 	}
 
 	registry := make([]*App, apps)
 	for i := range registry {
 		app := NewApp("app", Env{})
-		app.AddCommand(testCommand(ids[i%len(ids)], "name"))
+		app.AddCommand(testCommand(enabledIDs[i%len(enabledIDs)], "name"))
 		registry[i] = app
 	}
 
-	b.ResetTimer()
 	for b.Loop() {
-		if perApp {
-			// Old shape: every app rebuilds the system-wide set.
-			for _, app := range registry {
-				app.RemoveDanglingCommands(idLookupSet(ids))
-			}
-		} else {
-			// Current shape: built once, shared by every app.
-			set := idLookupSet(ids)
-			for _, app := range registry {
-				app.RemoveDanglingCommands(set)
-			}
+		set := util.IDSet(enabledIDs)
+		for _, app := range registry {
+			app.RemoveDanglingCommands(set)
 		}
 	}
 }
-
-func BenchmarkSweepSetPerApp(b *testing.B) { benchmarkSweep(b, 500, 5000, true) }
-func BenchmarkSweepSetShared(b *testing.B) { benchmarkSweep(b, 500, 5000, false) }

--- a/kite-service/internal/core/gateway/manager.go
+++ b/kite-service/internal/core/gateway/manager.go
@@ -307,10 +307,7 @@ func (m *GatewayManager) removeDanglingGateways(ctx context.Context, appIDs []st
 	m.Lock()
 	defer m.Unlock()
 
-	lookupMap := make(map[string]struct{}, len(appIDs))
-	for _, id := range appIDs {
-		lookupMap[id] = struct{}{}
-	}
+	lookupMap := util.IDSet(appIDs)
 
 	var removed int
 	for id := range m.gateways {

--- a/kite-service/internal/core/plan/manager.go
+++ b/kite-service/internal/core/plan/manager.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -65,6 +66,35 @@ func (m *PlanManager) AppFeatures(ctx context.Context, appID string) model.Featu
 		)
 	}
 
+	return m.featuresFromEntitlements(entitlements)
+}
+
+// AppFeaturesForApps resolves features for many apps in one round trip.
+//
+// Callers that need features for a set of apps must use this rather than
+// AppFeatures in a loop: that issued a query per app, which for the usage
+// manager meant one round trip for every app with usage that month, every
+// minute.
+//
+// Apps with no active entitlements still get the default plan's features, so
+// the result has an entry for every requested app.
+func (m *PlanManager) AppFeaturesForApps(ctx context.Context, appIDs []string) (map[string]model.Features, error) {
+	entitlements, err := m.entitlementStore.ActiveEntitlementsForApps(ctx, appIDs, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active entitlements: %w", err)
+	}
+
+	features := make(map[string]model.Features, len(appIDs))
+	for _, appID := range appIDs {
+		features[appID] = m.featuresFromEntitlements(entitlements[appID])
+	}
+
+	return features, nil
+}
+
+// featuresFromEntitlements merges the default plan with every plan the given
+// entitlements grant.
+func (m *PlanManager) featuresFromEntitlements(entitlements []*model.Entitlement) model.Features {
 	var features model.Features
 	for _, plan := range m.plans {
 		if plan.Default {

--- a/kite-service/internal/core/plan/manager.go
+++ b/kite-service/internal/core/plan/manager.go
@@ -69,12 +69,15 @@ func (m *PlanManager) AppFeatures(ctx context.Context, appID string) model.Featu
 	return m.featuresFromEntitlements(entitlements)
 }
 
+// DefaultFeatures returns the features every app gets without any
+// entitlement. Because Features.Merge takes the maximum of each field, no
+// app's resolved features can be below this, so callers looking for apps that
+// exceed a limit can rule out anything under it without a lookup.
+func (m *PlanManager) DefaultFeatures() model.Features {
+	return m.featuresFromEntitlements(nil)
+}
+
 // AppFeaturesForApps resolves features for many apps in one round trip.
-//
-// Callers that need features for a set of apps must use this rather than
-// AppFeatures in a loop: that issued a query per app, which for the usage
-// manager meant one round trip for every app with usage that month, every
-// minute.
 //
 // Apps with no active entitlements still get the default plan's features, so
 // the result has an entry for every requested app.

--- a/kite-service/internal/core/plan/manager_test.go
+++ b/kite-service/internal/core/plan/manager_test.go
@@ -1,0 +1,58 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/kitecloud/kite/kite-service/internal/model"
+)
+
+func testManager() *PlanManager {
+	return &PlanManager{
+		plans: []model.Plan{
+			{ID: "basic", Default: true, FeatureUsageCreditsPerMonth: 10000, FeatureMaxGuilds: 100},
+			{ID: "pro", FeatureUsageCreditsPerMonth: 100000, FeatureMaxGuilds: 500},
+		},
+	}
+}
+
+// The usage sweep skips the entitlement lookup for any app under this floor,
+// which is only sound because Merge takes the maximum of each field and the
+// default plan is always merged in.
+func TestDefaultFeaturesIsTheFloor(t *testing.T) {
+	m := testManager()
+
+	base := m.DefaultFeatures()
+	if base.UsageCreditsPerMonth != 10000 {
+		t.Errorf("default credits = %d, want the default plan's 10000", base.UsageCreditsPerMonth)
+	}
+
+	entitled := m.featuresFromEntitlements([]*model.Entitlement{{PlanID: "pro"}})
+	if entitled.UsageCreditsPerMonth < base.UsageCreditsPerMonth {
+		t.Errorf("entitled credits %d fell below the default floor %d",
+			entitled.UsageCreditsPerMonth, base.UsageCreditsPerMonth)
+	}
+	if entitled.UsageCreditsPerMonth != 100000 {
+		t.Errorf("entitled credits = %d, want the pro plan's 100000", entitled.UsageCreditsPerMonth)
+	}
+}
+
+// An entitlement naming a plan that no longer exists must not strip an app
+// back below the default.
+func TestFeaturesFromUnknownEntitlementKeepsDefault(t *testing.T) {
+	m := testManager()
+
+	got := m.featuresFromEntitlements([]*model.Entitlement{{PlanID: "removed-plan"}})
+	if got != m.DefaultFeatures() {
+		t.Errorf("unknown entitlement produced %+v, want the default features", got)
+	}
+}
+
+// With no default plan configured the floor is zero, so the sweep's filter
+// degenerates to checking every app rather than skipping any.
+func TestDefaultFeaturesWithNoDefaultPlan(t *testing.T) {
+	m := &PlanManager{plans: []model.Plan{{ID: "pro", FeatureUsageCreditsPerMonth: 100000}}}
+
+	if got := m.DefaultFeatures().UsageCreditsPerMonth; got != 0 {
+		t.Errorf("floor with no default plan = %d, want 0", got)
+	}
+}

--- a/kite-service/internal/core/usage/manager.go
+++ b/kite-service/internal/core/usage/manager.go
@@ -74,6 +74,11 @@ func (m *UsageManager) Run(ctx context.Context) {
 }
 
 func (m *UsageManager) disableAppsWithNoCredits(ctx context.Context) error {
+	// Run's context has no deadline, and this shares its goroutine with the
+	// cleanup tickers, so a stuck query would stall those too.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	start, end := startAndEndOfMonth(time.Now().UTC())
 
 	creditsUsed, err := m.usageStore.AllUsageCreditsUsedBetween(ctx, start, end)
@@ -81,24 +86,29 @@ func (m *UsageManager) disableAppsWithNoCredits(ctx context.Context) error {
 		return fmt.Errorf("failed to get all usage credits used: %w", err)
 	}
 
-	if len(creditsUsed) == 0 {
+	// An app can only be over its limit if it is over the allowance every app
+	// gets for free, so the rest need no entitlement lookup at all. That is
+	// the large majority of them.
+	floor := m.planManager.DefaultFeatures().UsageCreditsPerMonth
+
+	var candidates []string
+	for appID, used := range creditsUsed {
+		if used >= floor {
+			candidates = append(candidates, appID)
+		}
+	}
+
+	if len(candidates) == 0 {
 		return nil
 	}
 
-	// Resolved in one round trip. Asking per app meant a query for every app
-	// with usage this month, every minute.
-	appIDs := make([]string, 0, len(creditsUsed))
-	for appID := range creditsUsed {
-		appIDs = append(appIDs, appID)
-	}
-
-	features, err := m.planManager.AppFeaturesForApps(ctx, appIDs)
+	features, err := m.planManager.AppFeaturesForApps(ctx, candidates)
 	if err != nil {
 		return fmt.Errorf("failed to get features for apps: %w", err)
 	}
 
-	for appID, creditsUsed := range creditsUsed {
-		if creditsUsed < features[appID].UsageCreditsPerMonth {
+	for _, appID := range candidates {
+		if creditsUsed[appID] < features[appID].UsageCreditsPerMonth {
 			continue
 		}
 

--- a/kite-service/internal/core/usage/manager.go
+++ b/kite-service/internal/core/usage/manager.go
@@ -81,29 +81,51 @@ func (m *UsageManager) disableAppsWithNoCredits(ctx context.Context) error {
 		return fmt.Errorf("failed to get all usage credits used: %w", err)
 	}
 
+	if len(creditsUsed) == 0 {
+		return nil
+	}
+
+	// Resolved in one round trip. Asking per app meant a query for every app
+	// with usage this month, every minute.
+	appIDs := make([]string, 0, len(creditsUsed))
+	for appID := range creditsUsed {
+		appIDs = append(appIDs, appID)
+	}
+
+	features, err := m.planManager.AppFeaturesForApps(ctx, appIDs)
+	if err != nil {
+		return fmt.Errorf("failed to get features for apps: %w", err)
+	}
+
 	for appID, creditsUsed := range creditsUsed {
-		features := m.planManager.AppFeatures(ctx, appID)
-
-		if creditsUsed >= features.UsageCreditsPerMonth {
-			dCtx, cancel := context.WithTimeout(ctx, time.Second)
-			defer cancel()
-
-			err := m.appStore.DisableApp(dCtx, store.AppDisableOpts{
-				ID:             appID,
-				DisabledReason: null.StringFrom("No credits remaining"),
-				UpdatedAt:      time.Now().UTC(),
-			})
-			if err != nil {
-				slog.Error(
-					"Failed to disable app with no credits",
-					slog.String("app_id", appID),
-					slog.String("error", err.Error()),
-				)
-			}
+		if creditsUsed < features[appID].UsageCreditsPerMonth {
+			continue
 		}
+
+		m.disableApp(ctx, appID)
 	}
 
 	return nil
+}
+
+// disableApp is a separate function so its context is released when the app is
+// done rather than accumulating until the whole sweep returns.
+func (m *UsageManager) disableApp(ctx context.Context, appID string) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	err := m.appStore.DisableApp(ctx, store.AppDisableOpts{
+		ID:             appID,
+		DisabledReason: null.StringFrom("No credits remaining"),
+		UpdatedAt:      time.Now().UTC(),
+	})
+	if err != nil {
+		slog.Error(
+			"Failed to disable app with no credits",
+			slog.String("app_id", appID),
+			slog.String("error", err.Error()),
+		)
+	}
 }
 
 func (m *UsageManager) cleanupUsageRecords(ctx context.Context) error {

--- a/kite-service/internal/db/postgres/migrations/027_add_commands_updated_at_index.down.sql
+++ b/kite-service/internal/db/postgres/migrations/027_add_commands_updated_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS commands_enabled_updated_at;

--- a/kite-service/internal/db/postgres/migrations/027_add_commands_updated_at_index.up.sql
+++ b/kite-service/internal/db/postgres/migrations/027_add_commands_updated_at_index.up.sql
@@ -1,0 +1,17 @@
+-- The engine polls for changed commands every few seconds:
+--   SELECT * FROM commands WHERE enabled = TRUE AND updated_at > $1
+-- and commands was the one of the three polled tables with no index on
+-- updated_at, so every poll was a sequential scan -- over the widest of them,
+-- since commands carries a flow_source JSONB column.
+--
+-- Partial on enabled because both queries that use this column filter on it,
+-- and nothing reads commands.updated_at as a range without it. Migration 026
+-- already covers event_listeners and plugin_instances with an unconditional
+-- index, which their gateway requirements query needs.
+--
+-- Deliberately no INCLUDE (id) for the dangling sweep's "SELECT id WHERE
+-- enabled": that returns almost every row, and a sequential scan measured
+-- faster than the index-only scan it would enable (7.4ms vs 12.3ms at 100k
+-- rows), so the planner correctly ignores it.
+CREATE INDEX IF NOT EXISTS commands_enabled_updated_at
+    ON commands (updated_at) WHERE enabled;

--- a/kite-service/internal/db/postgres/migrations/028_add_usage_records_created_at_index.down.sql
+++ b/kite-service/internal/db/postgres/migrations/028_add_usage_records_created_at_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS usage_records_created_at;

--- a/kite-service/internal/db/postgres/migrations/028_add_usage_records_created_at_index.up.sql
+++ b/kite-service/internal/db/postgres/migrations/028_add_usage_records_created_at_index.up.sql
@@ -7,14 +7,11 @@
 -- usage_records takes a row per flow execution and is retained for three
 -- months, so both were sequential scans of the whole table.
 --
--- The hourly delete benefits unconditionally: it becomes an index-only scan to
--- find the cutoff. The per-minute aggregate benefits early in the month and
--- then stops -- measured at 1M rows, the planner uses the index while the
--- month-to-date range is a small fraction of retention and correctly falls
--- back to a parallel sequential scan once it approaches a third. Recomputing a
--- whole month's sum every minute is expensive by construction; not repeating
--- that work is a larger change than an index.
+-- The hourly delete benefits unconditionally, becoming an index-only scan to
+-- find the cutoff. The per-minute aggregate benefits while the month-to-date
+-- range is a small fraction of retention, and the planner correctly falls back
+-- to a sequential scan as it approaches a third.
 --
--- Writes are cheap despite this being the highest-write table: created_at is
+-- Writes stay cheap despite this being the highest-write table: created_at is
 -- effectively monotonic, so inserts append to the rightmost leaf.
 CREATE INDEX IF NOT EXISTS usage_records_created_at ON usage_records (created_at);

--- a/kite-service/internal/db/postgres/migrations/028_add_usage_records_created_at_index.up.sql
+++ b/kite-service/internal/db/postgres/migrations/028_add_usage_records_created_at_index.up.sql
@@ -1,0 +1,20 @@
+-- The usage manager reads this table on two schedules and neither had an index
+-- on created_at:
+--
+--   hourly:       DELETE ... WHERE created_at < $1
+--   every minute: SELECT app_id, SUM(credits_used) ... WHERE created_at BETWEEN
+--
+-- usage_records takes a row per flow execution and is retained for three
+-- months, so both were sequential scans of the whole table.
+--
+-- The hourly delete benefits unconditionally: it becomes an index-only scan to
+-- find the cutoff. The per-minute aggregate benefits early in the month and
+-- then stops -- measured at 1M rows, the planner uses the index while the
+-- month-to-date range is a small fraction of retention and correctly falls
+-- back to a parallel sequential scan once it approaches a third. Recomputing a
+-- whole month's sum every minute is expensive by construction; not repeating
+-- that work is a larger change than an index.
+--
+-- Writes are cheap despite this being the highest-write table: created_at is
+-- effectively monotonic, so inserts append to the rightmost leaf.
+CREATE INDEX IF NOT EXISTS usage_records_created_at ON usage_records (created_at);

--- a/kite-service/internal/db/postgres/pgmodel/apps.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/apps.sql.go
@@ -94,7 +94,7 @@ UPDATE apps SET
     enabled = FALSE,
     disabled_reason = $2,
     updated_at = $3
-WHERE id = $1
+WHERE id = $1 AND enabled
 `
 
 type DisableAppParams struct {
@@ -103,6 +103,8 @@ type DisableAppParams struct {
 	UpdatedAt      pgtype.Timestamp
 }
 
+// Idempotent: disabling an already-disabled app is a no-op rather than a write
+// that bumps updated_at, which several polls use as their cursor.
 func (q *Queries) DisableApp(ctx context.Context, arg DisableAppParams) error {
 	_, err := q.db.Exec(ctx, disableApp, arg.ID, arg.DisabledReason, arg.UpdatedAt)
 	return err

--- a/kite-service/internal/db/postgres/pgmodel/entitlements.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/entitlements.sql.go
@@ -49,6 +49,48 @@ func (q *Queries) GetActiveEntitlements(ctx context.Context, arg GetActiveEntitl
 	return items, nil
 }
 
+const getActiveEntitlementsForApps = `-- name: GetActiveEntitlementsForApps :many
+SELECT id, type, subscription_id, app_id, plan_id, created_at, updated_at, ends_at FROM entitlements
+WHERE app_id = ANY($1::text[]) AND (ends_at IS NULL OR ends_at > $2)
+ORDER BY created_at DESC
+`
+
+type GetActiveEntitlementsForAppsParams struct {
+	AppIds []string
+	EndsAt pgtype.Timestamp
+}
+
+// Batch form of GetActiveEntitlements. The usage manager checks every app with
+// usage this month, which was one round trip each.
+func (q *Queries) GetActiveEntitlementsForApps(ctx context.Context, arg GetActiveEntitlementsForAppsParams) ([]Entitlement, error) {
+	rows, err := q.db.Query(ctx, getActiveEntitlementsForApps, arg.AppIds, arg.EndsAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Entitlement
+	for rows.Next() {
+		var i Entitlement
+		if err := rows.Scan(
+			&i.ID,
+			&i.Type,
+			&i.SubscriptionID,
+			&i.AppID,
+			&i.PlanID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.EndsAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getEntitlements = `-- name: GetEntitlements :many
 SELECT id, type, subscription_id, app_id, plan_id, created_at, updated_at, ends_at FROM entitlements WHERE app_id = $1 ORDER BY created_at DESC
 `

--- a/kite-service/internal/db/postgres/pgmodel/usage_records.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/usage_records.sql.go
@@ -58,7 +58,10 @@ func (q *Queries) DeleteUsageRecordsBefore(ctx context.Context, beforeAt pgtype.
 }
 
 const getAllUsageCreditsUsedBetween = `-- name: GetAllUsageCreditsUsedBetween :many
-SELECT app_id, SUM(credits_used) FROM usage_records WHERE created_at BETWEEN $1 AND $2 GROUP BY app_id
+SELECT u.app_id, SUM(u.credits_used) FROM usage_records u
+JOIN apps a ON a.id = u.app_id AND a.enabled
+WHERE u.created_at BETWEEN $1 AND $2
+GROUP BY u.app_id
 `
 
 type GetAllUsageCreditsUsedBetweenParams struct {
@@ -71,6 +74,10 @@ type GetAllUsageCreditsUsedBetweenRow struct {
 	Sum   int64
 }
 
+// Only enabled apps. A disabled app's usage rows stay for the rest of the
+// month, so without this filter the credit sweep re-disables it on every run:
+// an UPDATE per app per minute, each bumping apps.updated_at, which is the
+// cursor GetDisabledAppIDsUpdatedSince feeds to the gateway manager's poll.
 func (q *Queries) GetAllUsageCreditsUsedBetween(ctx context.Context, arg GetAllUsageCreditsUsedBetweenParams) ([]GetAllUsageCreditsUsedBetweenRow, error) {
 	rows, err := q.db.Query(ctx, getAllUsageCreditsUsedBetween, arg.StartAt, arg.EndAt)
 	if err != nil {

--- a/kite-service/internal/db/postgres/queries/apps.sql
+++ b/kite-service/internal/db/postgres/queries/apps.sql
@@ -45,12 +45,14 @@ UPDATE apps SET
     updated_at = $8
 WHERE id = $1 RETURNING *;
 
+-- Idempotent: disabling an already-disabled app is a no-op rather than a write
+-- that bumps updated_at, which several polls use as their cursor.
 -- name: DisableApp :exec
 UPDATE apps SET
     enabled = FALSE,
     disabled_reason = $2,
     updated_at = $3
-WHERE id = $1;
+WHERE id = $1 AND enabled;
 
 -- name: DeleteApp :exec
 DELETE FROM apps WHERE id = $1;

--- a/kite-service/internal/db/postgres/queries/entitlements.sql
+++ b/kite-service/internal/db/postgres/queries/entitlements.sql
@@ -4,6 +4,13 @@ SELECT * FROM entitlements WHERE app_id = $1 ORDER BY created_at DESC;
 -- name: GetActiveEntitlements :many
 SELECT * FROM entitlements WHERE app_id = $1 AND (ends_at IS NULL OR ends_at > $2) ORDER BY created_at DESC;
 
+-- Batch form of GetActiveEntitlements. The usage manager checks every app with
+-- usage this month, which was one round trip each.
+-- name: GetActiveEntitlementsForApps :many
+SELECT * FROM entitlements
+WHERE app_id = ANY(@app_ids::text[]) AND (ends_at IS NULL OR ends_at > @ends_at)
+ORDER BY created_at DESC;
+
 -- name: UpsertSubscriptionEntitlement :one
 INSERT INTO entitlements (
     id,

--- a/kite-service/internal/db/postgres/queries/usage_records.sql
+++ b/kite-service/internal/db/postgres/queries/usage_records.sql
@@ -35,8 +35,15 @@ LEFT JOIN (
     GROUP BY DATE(created_at)
 ) u ON d.dt = u.date;
 
+-- Only enabled apps. A disabled app's usage rows stay for the rest of the
+-- month, so without this filter the credit sweep re-disables it on every run:
+-- an UPDATE per app per minute, each bumping apps.updated_at, which is the
+-- cursor GetDisabledAppIDsUpdatedSince feeds to the gateway manager's poll.
 -- name: GetAllUsageCreditsUsedBetween :many
-SELECT app_id, SUM(credits_used) FROM usage_records WHERE created_at BETWEEN @start_at AND @end_at GROUP BY app_id;
+SELECT u.app_id, SUM(u.credits_used) FROM usage_records u
+JOIN apps a ON a.id = u.app_id AND a.enabled
+WHERE u.created_at BETWEEN @start_at AND @end_at
+GROUP BY u.app_id;
 
 -- name: DeleteUsageRecordsBefore :exec
 DELETE FROM usage_records WHERE created_at < @before_at;

--- a/kite-service/internal/db/postgres/store_entitlement.go
+++ b/kite-service/internal/db/postgres/store_entitlement.go
@@ -24,6 +24,23 @@ func (c *Client) Entitlements(ctx context.Context, appID string) ([]*model.Entit
 	return entitlements, nil
 }
 
+func (c *Client) ActiveEntitlementsForApps(ctx context.Context, appIDs []string, now time.Time) (map[string][]*model.Entitlement, error) {
+	rows, err := c.Q.GetActiveEntitlementsForApps(ctx, pgmodel.GetActiveEntitlementsForAppsParams{
+		AppIds: appIDs,
+		EndsAt: pgtype.Timestamp{Time: now, Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	entitlements := make(map[string][]*model.Entitlement, len(appIDs))
+	for _, row := range rows {
+		entitlements[row.AppID] = append(entitlements[row.AppID], rowToEntitlement(row))
+	}
+
+	return entitlements, nil
+}
+
 func (c *Client) ActiveEntitlements(ctx context.Context, appID string, now time.Time) ([]*model.Entitlement, error) {
 	rows, err := c.Q.GetActiveEntitlements(ctx, pgmodel.GetActiveEntitlementsParams{
 		AppID:  appID,

--- a/kite-service/internal/db/postgres/store_entitlement.go
+++ b/kite-service/internal/db/postgres/store_entitlement.go
@@ -33,7 +33,9 @@ func (c *Client) ActiveEntitlementsForApps(ctx context.Context, appIDs []string,
 		return nil, err
 	}
 
-	entitlements := make(map[string][]*model.Entitlement, len(appIDs))
+	// Sized to rows, not appIDs: only apps that actually hold an
+	// entitlement get an entry, which is a small fraction of those asked about.
+	entitlements := make(map[string][]*model.Entitlement, len(rows))
 	for _, row := range rows {
 		entitlements[row.AppID] = append(entitlements[row.AppID], rowToEntitlement(row))
 	}

--- a/kite-service/internal/store/entitlement.go
+++ b/kite-service/internal/store/entitlement.go
@@ -10,8 +10,7 @@ import (
 type EntitlementStore interface {
 	Entitlements(ctx context.Context, appID string) ([]*model.Entitlement, error)
 	ActiveEntitlements(ctx context.Context, appID string, now time.Time) ([]*model.Entitlement, error)
-	// ActiveEntitlementsForApps is the batch form, keyed by app ID. Callers
-	// checking many apps should use it rather than a query per app.
+	// ActiveEntitlementsForApps is the batch form, keyed by app ID.
 	ActiveEntitlementsForApps(ctx context.Context, appIDs []string, now time.Time) (map[string][]*model.Entitlement, error)
 	UpsertSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error)
 	UpdateSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error)

--- a/kite-service/internal/store/entitlement.go
+++ b/kite-service/internal/store/entitlement.go
@@ -10,6 +10,9 @@ import (
 type EntitlementStore interface {
 	Entitlements(ctx context.Context, appID string) ([]*model.Entitlement, error)
 	ActiveEntitlements(ctx context.Context, appID string, now time.Time) ([]*model.Entitlement, error)
+	// ActiveEntitlementsForApps is the batch form, keyed by app ID. Callers
+	// checking many apps should use it rather than a query per app.
+	ActiveEntitlementsForApps(ctx context.Context, appIDs []string, now time.Time) (map[string][]*model.Entitlement, error)
 	UpsertSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error)
 	UpdateSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error)
 }

--- a/kite-service/internal/util/set.go
+++ b/kite-service/internal/util/set.go
@@ -1,0 +1,14 @@
+package util
+
+// IDSet builds a membership set from a slice of IDs.
+//
+// Callers that test many candidates against the same slice should build this
+// once and share it: the engine's dangling sweeps previously rebuilt an
+// equivalent map per app, which made them O(apps x entities).
+func IDSet[T comparable](ids []T) map[T]struct{} {
+	set := make(map[T]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set
+}

--- a/kite-service/internal/util/set_test.go
+++ b/kite-service/internal/util/set_test.go
@@ -1,0 +1,19 @@
+package util
+
+import "testing"
+
+func TestIDSet(t *testing.T) {
+	set := IDSet([]string{"a", "b", "a"})
+
+	if len(set) != 2 {
+		t.Errorf("IDSet produced %d entries, want 2 after dedup", len(set))
+	}
+	for _, want := range []string{"a", "b"} {
+		if _, ok := set[want]; !ok {
+			t.Errorf("IDSet is missing %q", want)
+		}
+	}
+	if _, ok := set["c"]; ok {
+		t.Error("IDSet contains an id that was not passed in")
+	}
+}


### PR DESCRIPTION
Caught in a production CPU profile of cluster 0. **`RemoveDanglingCommands` was 73.85% of all CPU samples** — 28.36s of 38.40s over a 30 second window.

```
     flat  flat%       cum   cum%
    5.83s 15.18%    28.36s 73.85%  engine.(*App).RemoveDanglingCommands
    3.07s  7.99%    21.01s 54.71%  runtime.mapassign_faststr
   12.70s 33.07%    12.70s 33.07%  internal/runtime/maps.ctrlGroup.matchH2
        0     0%     7.92s 20.62%  runtime.gcBgMarkWorker
```

## Cause

```go
func (a *App) RemoveDanglingCommands(commandIDs []string) {
    commandIDMap := make(map[string]struct{}, len(commandIDs))   // every enabled ID in the system
    for _, commandID := range commandIDs {
        commandIDMap[commandID] = struct{}{}
    }
    ...
}
```

The engine calls this once per app, and `commandIDs` is the system-wide set. With N apps and M entities that is O(N × M) insertions plus N allocations of an M-entry map. The event listener and plugin sweeps have the same shape.

Measured impact on the deployed cluster: the process sat at **1.28 cores during a sweep against 0.07 between them**, and the heap grew **1.4GB in 30 seconds** — which is also where the 20% GC mark work came from.

## Fix

The set is identical for every app, so it is built once per sweep and passed down.

Benchmark reproducing the production shape, 500 apps against 5,000 entities:

| | ns/op |
|---|---|
| set built per app (previous) | 37,761,736 |
| set built once (this PR) | **79,264** |

476× on those numbers, and the factor grows with app count — production has more of both.

## Notes

Pre-existing, not introduced by #320. Moving the sweep interval from 60s to 10m in that PR reduced how often this fired but not what it cost; at the old 60s interval a ~28s sweep was running every minute, which is close to half a core continuously per cluster.

Independent of #322 — different files, no conflict.