### PR TITLE
fix: asset degradation, event listener resume points, auto-defer traversal

### DIFF
--- a/kite-service/internal/api/handler/asset/handler.go
+++ b/kite-service/internal/api/handler/asset/handler.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -64,10 +65,22 @@ func (h *AssetHandler) HandleAssetCreate(c *handler.Context) (*wire.AssetCreateR
 		UpdatedAt:     time.Now().UTC(),
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrObjectStoreDisabled) {
+			return nil, errAssetsDisabled()
+		}
 		return nil, fmt.Errorf("failed to create asset: %w", err)
 	}
 
 	return wire.AssetToWire(asset, h.config.APIPublicBaseURL), nil
+}
+
+// Assets need object storage, which is optional. Without it, say so plainly
+// rather than surfacing a generic 500.
+func errAssetsDisabled() *handler.Error {
+	return handler.ErrServiceUnavailable(
+		"assets_disabled",
+		"this instance is not configured for file storage, so assets are unavailable",
+	)
 }
 
 func (h *AssetHandler) HandleAssetGet(c *handler.Context) (*wire.AssetGetResponse, error) {
@@ -96,8 +109,11 @@ func (h *AssetHandler) HandleAssetDownload(c *handler.Context) error {
 
 	asset, err := h.assetStore.AssetWithContent(c.Context(), c.Param("assetID"))
 	if err != nil {
-		if err == store.ErrNotFound {
+		if errors.Is(err, store.ErrNotFound) {
 			return handler.ErrNotFound("asset_not_found", "asset not found")
+		}
+		if errors.Is(err, store.ErrObjectStoreDisabled) {
+			return errAssetsDisabled()
 		}
 		return fmt.Errorf("failed to get asset: %w", err)
 	}

--- a/kite-service/internal/api/handler/asset/handler.go
+++ b/kite-service/internal/api/handler/asset/handler.go
@@ -65,22 +65,10 @@ func (h *AssetHandler) HandleAssetCreate(c *handler.Context) (*wire.AssetCreateR
 		UpdatedAt:     time.Now().UTC(),
 	})
 	if err != nil {
-		if errors.Is(err, store.ErrObjectStoreDisabled) {
-			return nil, errAssetsDisabled()
-		}
 		return nil, fmt.Errorf("failed to create asset: %w", err)
 	}
 
 	return wire.AssetToWire(asset, h.config.APIPublicBaseURL), nil
-}
-
-// Assets need object storage, which is optional. Without it, say so plainly
-// rather than surfacing a generic 500.
-func errAssetsDisabled() *handler.Error {
-	return handler.ErrServiceUnavailable(
-		"assets_disabled",
-		"this instance is not configured for file storage, so assets are unavailable",
-	)
 }
 
 func (h *AssetHandler) HandleAssetGet(c *handler.Context) (*wire.AssetGetResponse, error) {
@@ -111,9 +99,6 @@ func (h *AssetHandler) HandleAssetDownload(c *handler.Context) error {
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return handler.ErrNotFound("asset_not_found", "asset not found")
-		}
-		if errors.Is(err, store.ErrObjectStoreDisabled) {
-			return errAssetsDisabled()
 		}
 		return fmt.Errorf("failed to get asset: %w", err)
 	}

--- a/kite-service/internal/api/handler/error.go
+++ b/kite-service/internal/api/handler/error.go
@@ -57,6 +57,14 @@ func ErrInternal(message string) *Error {
 	}
 }
 
+func ErrServiceUnavailable(code, message string) *Error {
+	return &Error{
+		Status:  http.StatusServiceUnavailable,
+		Code:    code,
+		Message: message,
+	}
+}
+
 func ErrRateLimit(message string) *Error {
 	return &Error{
 		Status:  http.StatusTooManyRequests,

--- a/kite-service/internal/api/handler/handler.go
+++ b/kite-service/internal/api/handler/handler.go
@@ -9,6 +9,7 @@ import (
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/kitecloud/kite/kite-service/internal/api/wire"
+	"github.com/kitecloud/kite/kite-service/internal/store"
 )
 
 type HandlerFunc = func(c *Context) error
@@ -32,6 +33,14 @@ func APIHandler(f HandlerFunc) http.Handler {
 						Message: err.Error(),
 						Data:    err,
 					}
+				} else if errors.Is(err, store.ErrObjectStoreDisabled) {
+					// Object storage is optional and process-wide, so the
+					// answer is the same for every resource that needs it.
+					// Handled here so no caller can leak it as a 500.
+					aerr = ErrServiceUnavailable(
+						"assets_disabled",
+						"this instance is not configured for file storage, so assets are unavailable",
+					)
 				} else {
 					aerr = ErrInternal(err.Error())
 					slog.Error(

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kitecloud/kite/kite-service/internal/store"
 	"github.com/kitecloud/kite/kite-service/pkg/flow"
 	"github.com/kitecloud/kite/kite-service/pkg/message"
-	"gopkg.in/guregu/null.v4"
 )
 
 type App struct {
@@ -246,21 +245,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 			customID := string(d.CustomID)
 			resumePointID, _, isResume := message.DecodeCustomIDMessageComponentResumePoint(customID)
 			if isResume {
-				resumePoint, err := a.env.ResumePointStore.ResumePoint(context.TODO(), resumePointID)
-				if err != nil {
-					if errors.Is(err, store.ErrNotFound) {
-						return
-					}
-
-					slog.Error(
-						"Failed to get resume point",
-						slog.String("resume_point_id", resumePointID),
-						slog.String("error", err.Error()),
-					)
-					return
-				}
-
-				a.resumeFlow(resumePoint, session, event)
+				a.resumeFlow(resumePointID, session, event)
 				return
 			}
 
@@ -293,21 +278,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 				return
 			}
 
-			resumePoint, err := a.env.ResumePointStore.ResumePoint(context.TODO(), resumePointID)
-			if err != nil {
-				if errors.Is(err, store.ErrNotFound) {
-					return
-				}
-
-				slog.Error(
-					"Failed to get resume point",
-					slog.String("resume_point_id", resumePointID),
-					slog.String("error", err.Error()),
-				)
-				return
-			}
-
-			a.resumeFlow(resumePoint, session, event)
+			a.resumeFlow(resumePointID, session, event)
 		}
 	default:
 		eventType := model.EventTypeFromDiscordEventType(e.EventType())
@@ -324,19 +295,32 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 	}
 }
 
-// resumeFlow dispatches a resume point back into the flow that created it.
+// resumeFlow loads a resume point and dispatches it back into the flow that
+// created it.
 //
 // A resume point is owned by whatever ran the flow: a command, an event
 // listener, or a message instance. Every owner has to be handled here — an
 // unhandled one means the interaction never gets a response, which Discord
 // shows to the user as "This interaction failed".
 func (a *App) resumeFlow(
-	resumePoint *model.ResumePoint,
+	resumePointID string,
 	session *state.State,
 	event gateway.Event,
 ) {
-	targetFlow, links, ok := a.resumeFlowTarget(resumePoint)
-	if !ok {
+	resumePoint, err := a.env.ResumePointStore.ResumePoint(context.TODO(), resumePointID)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			slog.Error(
+				"Failed to get resume point",
+				slog.String("resume_point_id", resumePointID),
+				slog.String("error", err.Error()),
+			)
+		}
+		return
+	}
+
+	targetFlow := a.resumeFlowTarget(resumePoint)
+	if targetFlow == nil {
 		return
 	}
 
@@ -356,39 +340,46 @@ func (a *App) resumeFlow(
 		node,
 		session,
 		event,
-		links,
+		entityLinksFromResumePoint(resumePoint),
 		&resumePoint.FlowState,
 	)
 }
 
-// resumeFlowTarget resolves which flow a resume point belongs to, along with
-// the entity links used to attribute the resumed execution.
-func (a *App) resumeFlowTarget(
-	resumePoint *model.ResumePoint,
-) (*flow.CompiledFlowNode, entityLinks, bool) {
+// entityLinksFromResumePoint recovers the links the flow was running with when
+// it suspended. CreateResumePoint stores them verbatim, so attribution of logs
+// and usage survives the suspend rather than being guessed on the way back in.
+func entityLinksFromResumePoint(resumePoint *model.ResumePoint) entityLinks {
+	return entityLinks{
+		CommandID:         resumePoint.CommandID,
+		EventListenerID:   resumePoint.EventListenerID,
+		MessageID:         resumePoint.MessageID,
+		MessageInstanceID: resumePoint.MessageInstanceID,
+		FlowSourceID:      resumePoint.FlowSourceID,
+	}
+}
+
+// resumeFlowTarget resolves which compiled flow a resume point belongs to, or
+// nil if its owner is gone.
+func (a *App) resumeFlowTarget(resumePoint *model.ResumePoint) *flow.CompiledFlowNode {
 	switch {
 	case resumePoint.CommandID.Valid:
 		a.RLock()
 		command, ok := a.commands[resumePoint.CommandID.String]
 		a.RUnlock()
 		if !ok {
-			return nil, entityLinks{}, false
+			return nil
 		}
 
-		return command.flow, entityLinks{
-			CommandID: null.NewString(command.cmd.ID, true),
-		}, true
+		return command.flow
 	case resumePoint.EventListenerID.Valid:
 		a.RLock()
 		listener, ok := a.listeners[resumePoint.EventListenerID.String]
 		a.RUnlock()
 		if !ok {
-			return nil, entityLinks{}, false
+			return nil
 		}
 
-		return listener.flow, entityLinks{
-			EventListenerID: null.NewString(listener.listener.ID, true),
-		}, true
+		return listener.flow
 	case resumePoint.MessageInstanceID.Valid:
 		messageInstance, err := a.env.MessageInstanceStore.MessageInstance(
 			context.TODO(),
@@ -405,7 +396,7 @@ func (a *App) resumeFlowTarget(
 					slog.String("error", err.Error()),
 				)
 			}
-			return nil, entityLinks{}, false
+			return nil
 		}
 
 		instance, err := NewMessageInstance(a.id, messageInstance, a.env)
@@ -417,28 +408,16 @@ func (a *App) resumeFlowTarget(
 				slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
 				slog.String("error", err.Error()),
 			)
-			return nil, entityLinks{}, false
+			return nil
 		}
 
-		instanceFlow, ok := instance.flows[resumePoint.FlowSourceID.String]
-		if !ok {
-			slog.Error(
-				"Failed to get target flow from resume point",
-				slog.String("resume_point_id", resumePoint.ID),
-				slog.String("message_id", resumePoint.MessageID.String),
-				slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
-				slog.String("flow_source_id", resumePoint.FlowSourceID.String),
-			)
-			return nil, entityLinks{}, false
-		}
-
-		return instanceFlow, entityLinks{}, true
+		return instance.flows[resumePoint.FlowSourceID.String]
 	default:
 		slog.Error(
 			"Resume point has no owning command, event listener or message instance",
 			slog.String("resume_point_id", resumePoint.ID),
 		)
-		return nil, entityLinks{}, false
+		return nil
 	}
 }
 

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kitecloud/kite/kite-service/internal/metrics"
 	"github.com/kitecloud/kite/kite-service/internal/model"
 	"github.com/kitecloud/kite/kite-service/internal/store"
+	"github.com/kitecloud/kite/kite-service/pkg/flow"
 	"github.com/kitecloud/kite/kite-service/pkg/message"
 	"gopkg.in/guregu/null.v4"
 )
@@ -259,37 +260,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 					return
 				}
 
-				if resumePoint.CommandID.Valid {
-					a.RLock()
-					defer a.RUnlock()
-
-					command, ok := a.commands[resumePoint.CommandID.String]
-					if !ok {
-						return
-					}
-
-					node := command.flow.FindChildWithID(resumePoint.FlowNodeID, true)
-					if node == nil {
-						slog.Error(
-							"Failed to find node in flow",
-							slog.String("resume_point_id", resumePointID),
-							slog.String("command_id", resumePoint.CommandID.String),
-						)
-						return
-					}
-
-					go a.env.executeFlowEvent(
-						context.Background(),
-						a.id,
-						node,
-						session,
-						event,
-						entityLinks{
-							CommandID: null.NewString(command.cmd.ID, true),
-						},
-						&resumePoint.FlowState,
-					)
-				}
+				a.resumeFlow(resumePoint, session, event)
 				return
 			}
 
@@ -336,107 +307,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 				return
 			}
 
-			if resumePoint.CommandID.Valid {
-				a.RLock()
-				defer a.RUnlock()
-
-				command, ok := a.commands[resumePoint.CommandID.String]
-				if !ok {
-					return
-				}
-
-				node := command.flow.FindChildWithID(resumePoint.FlowNodeID, true)
-				if node == nil {
-					slog.Error(
-						"Failed to find node in flow",
-						slog.String("resume_point_id", resumePointID),
-						slog.String("command_id", resumePoint.CommandID.String),
-					)
-					return
-				}
-
-				go a.env.executeFlowEvent(
-					context.Background(),
-					a.id,
-					node,
-					session,
-					event,
-					entityLinks{
-						CommandID: null.NewString(command.cmd.ID, true),
-					},
-					&resumePoint.FlowState,
-				)
-			}
-
-			if resumePoint.MessageInstanceID.Valid {
-				messageInstance, err := a.env.MessageInstanceStore.MessageInstance(
-					context.TODO(),
-					resumePoint.MessageID.String,
-					uint64(resumePoint.MessageInstanceID.Int64),
-				)
-				if err != nil {
-					if !errors.Is(err, store.ErrNotFound) {
-						slog.Error(
-							"Failed to get message instance from resume point",
-							slog.String("resume_point_id", resumePointID),
-							slog.String("message_id", resumePoint.MessageID.String),
-							slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
-							slog.String("error", err.Error()),
-						)
-					}
-					return
-				}
-
-				instance, err := NewMessageInstance(
-					a.id,
-					messageInstance,
-					a.env,
-				)
-				if err != nil {
-					slog.Error(
-						"Failed to create message instance",
-						slog.String("resume_point_id", resumePointID),
-						slog.String("message_id", resumePoint.MessageID.String),
-						slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
-						slog.String("error", err.Error()),
-					)
-					return
-				}
-
-				targetFlow, ok := instance.flows[resumePoint.FlowSourceID.String]
-				if !ok {
-					slog.Error(
-						"Failed to get target flow from resume point",
-						slog.String("resume_point_id", resumePointID),
-						slog.String("message_id", resumePoint.MessageID.String),
-						slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
-						slog.String("flow_source_id", resumePoint.FlowSourceID.String),
-					)
-					return
-				}
-
-				node := targetFlow.FindChildWithID(resumePoint.FlowNodeID, true)
-				if node == nil {
-					slog.Error(
-						"Failed to find node in flow",
-						slog.String("resume_point_id", resumePointID),
-						slog.String("message_id", resumePoint.MessageID.String),
-						slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
-						slog.String("flow_source_id", resumePoint.FlowSourceID.String),
-					)
-					return
-				}
-
-				go a.env.executeFlowEvent(
-					context.Background(),
-					a.id,
-					node,
-					session,
-					event,
-					entityLinks{},
-					&resumePoint.FlowState,
-				)
-			}
+			a.resumeFlow(resumePoint, session, event)
 		}
 	default:
 		eventType := model.EventTypeFromDiscordEventType(e.EventType())
@@ -450,6 +321,124 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 		for _, listener := range listeners {
 			go listener.HandleEvent(appID, session, event)
 		}
+	}
+}
+
+// resumeFlow dispatches a resume point back into the flow that created it.
+//
+// A resume point is owned by whatever ran the flow: a command, an event
+// listener, or a message instance. Every owner has to be handled here — an
+// unhandled one means the interaction never gets a response, which Discord
+// shows to the user as "This interaction failed".
+func (a *App) resumeFlow(
+	resumePoint *model.ResumePoint,
+	session *state.State,
+	event gateway.Event,
+) {
+	targetFlow, links, ok := a.resumeFlowTarget(resumePoint)
+	if !ok {
+		return
+	}
+
+	node := targetFlow.FindChildWithID(resumePoint.FlowNodeID, true)
+	if node == nil {
+		slog.Error(
+			"Failed to find node in flow",
+			slog.String("resume_point_id", resumePoint.ID),
+			slog.String("flow_node_id", resumePoint.FlowNodeID),
+		)
+		return
+	}
+
+	go a.env.executeFlowEvent(
+		context.Background(),
+		a.id,
+		node,
+		session,
+		event,
+		links,
+		&resumePoint.FlowState,
+	)
+}
+
+// resumeFlowTarget resolves which flow a resume point belongs to, along with
+// the entity links used to attribute the resumed execution.
+func (a *App) resumeFlowTarget(
+	resumePoint *model.ResumePoint,
+) (*flow.CompiledFlowNode, entityLinks, bool) {
+	switch {
+	case resumePoint.CommandID.Valid:
+		a.RLock()
+		command, ok := a.commands[resumePoint.CommandID.String]
+		a.RUnlock()
+		if !ok {
+			return nil, entityLinks{}, false
+		}
+
+		return command.flow, entityLinks{
+			CommandID: null.NewString(command.cmd.ID, true),
+		}, true
+	case resumePoint.EventListenerID.Valid:
+		a.RLock()
+		listener, ok := a.listeners[resumePoint.EventListenerID.String]
+		a.RUnlock()
+		if !ok {
+			return nil, entityLinks{}, false
+		}
+
+		return listener.flow, entityLinks{
+			EventListenerID: null.NewString(listener.listener.ID, true),
+		}, true
+	case resumePoint.MessageInstanceID.Valid:
+		messageInstance, err := a.env.MessageInstanceStore.MessageInstance(
+			context.TODO(),
+			resumePoint.MessageID.String,
+			uint64(resumePoint.MessageInstanceID.Int64),
+		)
+		if err != nil {
+			if !errors.Is(err, store.ErrNotFound) {
+				slog.Error(
+					"Failed to get message instance from resume point",
+					slog.String("resume_point_id", resumePoint.ID),
+					slog.String("message_id", resumePoint.MessageID.String),
+					slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
+					slog.String("error", err.Error()),
+				)
+			}
+			return nil, entityLinks{}, false
+		}
+
+		instance, err := NewMessageInstance(a.id, messageInstance, a.env)
+		if err != nil {
+			slog.Error(
+				"Failed to create message instance",
+				slog.String("resume_point_id", resumePoint.ID),
+				slog.String("message_id", resumePoint.MessageID.String),
+				slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
+				slog.String("error", err.Error()),
+			)
+			return nil, entityLinks{}, false
+		}
+
+		instanceFlow, ok := instance.flows[resumePoint.FlowSourceID.String]
+		if !ok {
+			slog.Error(
+				"Failed to get target flow from resume point",
+				slog.String("resume_point_id", resumePoint.ID),
+				slog.String("message_id", resumePoint.MessageID.String),
+				slog.Int64("message_instance_id", resumePoint.MessageInstanceID.Int64),
+				slog.String("flow_source_id", resumePoint.FlowSourceID.String),
+			)
+			return nil, entityLinks{}, false
+		}
+
+		return instanceFlow, entityLinks{}, true
+	default:
+		slog.Error(
+			"Resume point has no owning command, event listener or message instance",
+			slog.String("resume_point_id", resumePoint.ID),
+		)
+		return nil, entityLinks{}, false
 	}
 }
 

--- a/kite-service/internal/core/engine/app_test.go
+++ b/kite-service/internal/core/engine/app_test.go
@@ -154,28 +154,17 @@ func TestListenerIndexRebuildDoesNotMutateExistingSlice(t *testing.T) {
 // or modal inside an event listener flow resolved to nothing, so the
 // interaction got no response and Discord showed "This interaction failed".
 
-func testResumePoint(rp model.ResumePoint) *model.ResumePoint {
-	rp.ID = "resume-1"
-	return &rp
-}
-
 func TestResumeFlowTargetResolvesCommand(t *testing.T) {
 	app := NewApp("app-1", Env{})
 	id, command := testCommand("cmd-1", "ping")
 	command.flow = &flow.CompiledFlowNode{}
 	app.AddCommand(id, command)
 
-	targetFlow, links, ok := app.resumeFlowTarget(testResumePoint(model.ResumePoint{
+	targetFlow := app.resumeFlowTarget(&model.ResumePoint{
 		CommandID: null.NewString("cmd-1", true),
-	}))
-	if !ok {
-		t.Fatal("command-owned resume point did not resolve")
-	}
+	})
 	if targetFlow != command.flow {
-		t.Error("resolved to the wrong flow")
-	}
-	if links.CommandID.String != "cmd-1" {
-		t.Errorf("links.CommandID = %q, want cmd-1", links.CommandID.String)
+		t.Error("command-owned resume point did not resolve to its flow")
 	}
 }
 
@@ -185,20 +174,11 @@ func TestResumeFlowTargetResolvesEventListener(t *testing.T) {
 	listener.flow = &flow.CompiledFlowNode{}
 	app.AddEventListener(id, listener)
 
-	targetFlow, links, ok := app.resumeFlowTarget(testResumePoint(model.ResumePoint{
+	targetFlow := app.resumeFlowTarget(&model.ResumePoint{
 		EventListenerID: null.NewString("lst-1", true),
-	}))
-	if !ok {
-		t.Fatal("event listener resume point did not resolve; buttons in listener flows are dead")
-	}
+	})
 	if targetFlow != listener.flow {
-		t.Error("resolved to the wrong flow")
-	}
-	if links.EventListenerID.String != "lst-1" {
-		t.Errorf("links.EventListenerID = %q, want lst-1", links.EventListenerID.String)
-	}
-	if links.CommandID.Valid {
-		t.Error("listener execution must not be attributed to a command")
+		t.Error("event listener resume point did not resolve; buttons in listener flows are dead")
 	}
 }
 
@@ -207,13 +187,29 @@ func TestResumeFlowTargetResolvesEventListener(t *testing.T) {
 func TestResumeFlowTargetUnknownOwner(t *testing.T) {
 	app := NewApp("app-1", Env{})
 
-	for name, rp := range map[string]model.ResumePoint{
+	for name, resumePoint := range map[string]model.ResumePoint{
 		"missing command":  {CommandID: null.NewString("nope", true)},
 		"missing listener": {EventListenerID: null.NewString("nope", true)},
 		"no owner":         {},
 	} {
-		if _, _, ok := app.resumeFlowTarget(testResumePoint(rp)); ok {
-			t.Errorf("%s: resolved, want no target", name)
+		if got := app.resumeFlowTarget(&resumePoint); got != nil {
+			t.Errorf("%s: resolved to a flow, want nil", name)
 		}
+	}
+}
+
+// Links are stored on the resume point when the flow suspends, so attribution
+// of logs and usage has to survive the round trip rather than be rebuilt.
+func TestEntityLinksFromResumePoint(t *testing.T) {
+	links := entityLinksFromResumePoint(&model.ResumePoint{
+		MessageID:         null.NewString("msg-1", true),
+		MessageInstanceID: null.NewInt(7, true),
+		FlowSourceID:      null.NewString("src-1", true),
+	})
+
+	if links.MessageID.String != "msg-1" ||
+		links.MessageInstanceID.Int64 != 7 ||
+		links.FlowSourceID.String != "src-1" {
+		t.Errorf("message instance attribution lost: %+v", links)
 	}
 }

--- a/kite-service/internal/core/engine/app_test.go
+++ b/kite-service/internal/core/engine/app_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/kitecloud/kite/kite-service/internal/model"
 	"github.com/kitecloud/kite/kite-service/internal/util"
+	"github.com/kitecloud/kite/kite-service/pkg/flow"
+	"gopkg.in/guregu/null.v4"
 )
 
 // The command and listener lookup indexes replaced linear scans over every
@@ -144,5 +146,74 @@ func TestListenerIndexRebuildDoesNotMutateExistingSlice(t *testing.T) {
 	}
 	if snapshot[0].listener.ID != "l-1" {
 		t.Errorf("snapshot contents changed: got %q, want l-1", snapshot[0].listener.ID)
+	}
+}
+
+// Resume points are created by commands, event listeners and message
+// instances alike, but dispatch only ever handled the command case. A button
+// or modal inside an event listener flow resolved to nothing, so the
+// interaction got no response and Discord showed "This interaction failed".
+
+func testResumePoint(rp model.ResumePoint) *model.ResumePoint {
+	rp.ID = "resume-1"
+	return &rp
+}
+
+func TestResumeFlowTargetResolvesCommand(t *testing.T) {
+	app := NewApp("app-1", Env{})
+	id, command := testCommand("cmd-1", "ping")
+	command.flow = &flow.CompiledFlowNode{}
+	app.AddCommand(id, command)
+
+	targetFlow, links, ok := app.resumeFlowTarget(testResumePoint(model.ResumePoint{
+		CommandID: null.NewString("cmd-1", true),
+	}))
+	if !ok {
+		t.Fatal("command-owned resume point did not resolve")
+	}
+	if targetFlow != command.flow {
+		t.Error("resolved to the wrong flow")
+	}
+	if links.CommandID.String != "cmd-1" {
+		t.Errorf("links.CommandID = %q, want cmd-1", links.CommandID.String)
+	}
+}
+
+func TestResumeFlowTargetResolvesEventListener(t *testing.T) {
+	app := NewApp("app-1", Env{})
+	id, listener := testListener("lst-1", model.EventSourceDiscord, model.EventListenerTypeDiscordMessageCreate)
+	listener.flow = &flow.CompiledFlowNode{}
+	app.AddEventListener(id, listener)
+
+	targetFlow, links, ok := app.resumeFlowTarget(testResumePoint(model.ResumePoint{
+		EventListenerID: null.NewString("lst-1", true),
+	}))
+	if !ok {
+		t.Fatal("event listener resume point did not resolve; buttons in listener flows are dead")
+	}
+	if targetFlow != listener.flow {
+		t.Error("resolved to the wrong flow")
+	}
+	if links.EventListenerID.String != "lst-1" {
+		t.Errorf("links.EventListenerID = %q, want lst-1", links.EventListenerID.String)
+	}
+	if links.CommandID.Valid {
+		t.Error("listener execution must not be attributed to a command")
+	}
+}
+
+// A resume point whose owner is gone (deleted or disabled) must resolve to
+// nothing rather than panic.
+func TestResumeFlowTargetUnknownOwner(t *testing.T) {
+	app := NewApp("app-1", Env{})
+
+	for name, rp := range map[string]model.ResumePoint{
+		"missing command":  {CommandID: null.NewString("nope", true)},
+		"missing listener": {EventListenerID: null.NewString("nope", true)},
+		"no owner":         {},
+	} {
+		if _, _, ok := app.resumeFlowTarget(testResumePoint(rp)); ok {
+			t.Errorf("%s: resolved, want no target", name)
+		}
 	}
 }

--- a/kite-service/internal/db/postgres/store_asset.go
+++ b/kite-service/internal/db/postgres/store_asset.go
@@ -34,6 +34,19 @@ func NewAssetStore(ctx context.Context, pg *Client, objectStore store.ObjectStor
 }
 
 func (s *AssetStore) CreateAsset(ctx context.Context, asset *model.Asset) (*model.Asset, error) {
+	// Upload before inserting the row. The other order leaves a row pointing
+	// at content that was never stored whenever the upload fails, which breaks
+	// every later read of that asset. Objects are content-addressed, so an
+	// upload with no row is harmless and reusable.
+	err := s.objectStore.UploadObject(ctx, assetBucketName, &model.Object{
+		Name:        asset.ContentHash,
+		Content:     asset.Content,
+		ContentType: asset.ContentType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to upload asset object: %w", err)
+	}
+
 	row, err := s.pg.Q.CreateAsset(ctx, pgmodel.CreateAssetParams{
 		ID:          asset.ID,
 		Name:        asset.Name,
@@ -61,15 +74,6 @@ func (s *AssetStore) CreateAsset(ctx context.Context, asset *model.Asset) (*mode
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create asset: %w", err)
-	}
-
-	err = s.objectStore.UploadObject(ctx, assetBucketName, &model.Object{
-		Name:        asset.ContentHash,
-		Content:     asset.Content,
-		ContentType: asset.ContentType,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to upload asset object: %w", err)
 	}
 
 	return rowToAsset(row)

--- a/kite-service/internal/db/postgres/store_asset_test.go
+++ b/kite-service/internal/db/postgres/store_asset_test.go
@@ -1,0 +1,36 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kitecloud/kite/kite-service/internal/model"
+	"github.com/kitecloud/kite/kite-service/internal/store"
+)
+
+// CreateAsset must upload the object before inserting the row, so that a
+// failed upload never leaves a row pointing at content that isn't stored.
+//
+// The nil *Client is the assertion: if the insert ran first it would panic on
+// s.pg.Q, so reaching a clean error proves the upload happens first.
+func TestCreateAssetUploadsBeforeInsert(t *testing.T) {
+	s := &AssetStore{pg: nil, objectStore: store.DisabledObjectStore{}}
+
+	asset, err := s.CreateAsset(context.Background(), &model.Asset{
+		ID:          "asset-id",
+		AppID:       "app-id",
+		ContentHash: "hash",
+		ContentType: "image/png",
+		Content:     []byte("content"),
+	})
+	if err == nil {
+		t.Fatal("expected an error when the object store is disabled")
+	}
+	if asset != nil {
+		t.Fatalf("expected no asset, got %+v", asset)
+	}
+	if !errors.Is(err, store.ErrObjectStoreDisabled) {
+		t.Fatalf("expected ErrObjectStoreDisabled, got: %v", err)
+	}
+}

--- a/kite-service/pkg/flow/autodefer_test.go
+++ b/kite-service/pkg/flow/autodefer_test.go
@@ -1,0 +1,134 @@
+package flow
+
+import "testing"
+
+// The auto-defer has to declare ephemeral-ness before the flow picks a branch,
+// so it guesses from the first response node it can reach. The guess used to
+// be made with FindChildWithType, which only walks Children.Default -- so a
+// response behind a condition or button handle was invisible and the flow
+// deferred public even when its only response was ephemeral.
+//
+// These tests deliberately do NOT assert that an ephemeral response anywhere
+// forces an ephemeral defer. The defer only binds a response that edits the
+// original, so promoting every flow with an ephemeral branch would force
+// intended-public first responses ephemeral.
+
+func responseNode(id string, ephemeral bool) *CompiledFlowNode {
+	return &CompiledFlowNode{
+		ID:   id,
+		Type: FlowNodeTypeActionResponseCreate,
+		Data: FlowNodeData{MessageEphemeral: ephemeral},
+	}
+}
+
+func entryWith(defaults []*CompiledFlowNode, handles map[string][]*CompiledFlowNode) *CompiledFlowNode {
+	if handles == nil {
+		handles = map[string][]*CompiledFlowNode{}
+	}
+	return &CompiledFlowNode{
+		ID:       "entry",
+		Type:     FlowNodeTypeEntryCommand,
+		Children: ConnectedFlowNodes{Default: defaults, Handles: handles},
+	}
+}
+
+func firstResponse(t *testing.T, entry *CompiledFlowNode) *CompiledFlowNode {
+	t.Helper()
+	return entry.FirstChildMatching(isResponseNode)
+}
+
+// The reported bug: the only response sits behind a condition branch, so the
+// old walker found nothing and deferred public.
+func TestResponseBehindHandleIsFound(t *testing.T) {
+	entry := entryWith(nil, map[string][]*CompiledFlowNode{
+		"condition_1": {responseNode("ephemeral", true)},
+	})
+
+	found := firstResponse(t, entry)
+	if found == nil {
+		t.Fatal("response behind a handle was not found")
+	}
+	if !found.Data.MessageEphemeral {
+		t.Error("found response is not the ephemeral one")
+	}
+}
+
+// A public first response must stay public even when a later branch responds
+// ephemerally, otherwise the defer forces the public reply ephemeral.
+func TestPublicFirstResponseWinsOverEphemeralBranch(t *testing.T) {
+	entry := entryWith(
+		[]*CompiledFlowNode{responseNode("public", false)},
+		map[string][]*CompiledFlowNode{
+			"condition_1": {responseNode("ephemeral", true)},
+		},
+	)
+
+	found := firstResponse(t, entry)
+	if found == nil {
+		t.Fatal("no response found")
+	}
+	if found.Data.MessageEphemeral {
+		t.Error("deferred ephemeral, which would force the public response ephemeral")
+	}
+}
+
+// Direct children are reached before deeper ones.
+func TestDirectChildPreferredOverNested(t *testing.T) {
+	nested := entryWith([]*CompiledFlowNode{responseNode("deep", true)}, nil)
+	nested.ID = "nested"
+	nested.Type = FlowNodeTypeControlConditionCompare
+
+	entry := entryWith([]*CompiledFlowNode{nested, responseNode("shallow", false)}, nil)
+
+	found := firstResponse(t, entry)
+	if found == nil || found.ID != "shallow" {
+		t.Errorf("found %v, want the direct child", found)
+	}
+}
+
+// Handle iteration must not depend on Go's random map order, or the same flow
+// would defer differently between runs.
+func TestHandleOrderIsStable(t *testing.T) {
+	build := func() *CompiledFlowNode {
+		return entryWith(nil, map[string][]*CompiledFlowNode{
+			"a_branch": {responseNode("a", false)},
+			"b_branch": {responseNode("b", true)},
+			"c_branch": {responseNode("c", true)},
+		})
+	}
+
+	want := firstResponse(t, build())
+	for i := 0; i < 50; i++ {
+		if got := firstResponse(t, build()); got.ID != want.ID {
+			t.Fatalf("iteration %d picked %q, want %q", i, got.ID, want.ID)
+		}
+	}
+}
+
+// Non-response nodes carry MessageEphemeral too and must not be mistaken for a
+// response.
+func TestNonResponseNodeIgnored(t *testing.T) {
+	entry := entryWith([]*CompiledFlowNode{{
+		ID:   "send",
+		Type: FlowNodeTypeActionMessageCreate,
+		Data: FlowNodeData{MessageEphemeral: true},
+	}}, nil)
+
+	if found := firstResponse(t, entry); found != nil {
+		t.Errorf("non-response node %q counted as a response", found.ID)
+	}
+}
+
+// Flows can loop back on themselves; the walk must terminate.
+func TestCycleTerminates(t *testing.T) {
+	a := &CompiledFlowNode{ID: "a", Children: ConnectedFlowNodes{Handles: map[string][]*CompiledFlowNode{}}}
+	b := &CompiledFlowNode{ID: "b", Children: ConnectedFlowNodes{Handles: map[string][]*CompiledFlowNode{}}}
+	a.Children.Default = []*CompiledFlowNode{b}
+	b.Children.Default = []*CompiledFlowNode{a}
+
+	entry := entryWith([]*CompiledFlowNode{a}, nil)
+
+	if found := firstResponse(t, entry); found != nil {
+		t.Errorf("unexpected match %q in a cyclic flow", found.ID)
+	}
+}

--- a/kite-service/pkg/flow/autodefer_test.go
+++ b/kite-service/pkg/flow/autodefer_test.go
@@ -13,7 +13,7 @@ import "testing"
 // original, so promoting every flow with an ephemeral branch would force
 // intended-public first responses ephemeral.
 
-func responseNode(id string, ephemeral bool) *CompiledFlowNode {
+func newResponseNode(id string, ephemeral bool) *CompiledFlowNode {
 	return &CompiledFlowNode{
 		ID:   id,
 		Type: FlowNodeTypeActionResponseCreate,
@@ -22,9 +22,6 @@ func responseNode(id string, ephemeral bool) *CompiledFlowNode {
 }
 
 func entryWith(defaults []*CompiledFlowNode, handles map[string][]*CompiledFlowNode) *CompiledFlowNode {
-	if handles == nil {
-		handles = map[string][]*CompiledFlowNode{}
-	}
 	return &CompiledFlowNode{
 		ID:       "entry",
 		Type:     FlowNodeTypeEntryCommand,
@@ -32,8 +29,7 @@ func entryWith(defaults []*CompiledFlowNode, handles map[string][]*CompiledFlowN
 	}
 }
 
-func firstResponse(t *testing.T, entry *CompiledFlowNode) *CompiledFlowNode {
-	t.Helper()
+func firstResponse(entry *CompiledFlowNode) *CompiledFlowNode {
 	return entry.FirstChildMatching(isResponseNode)
 }
 
@@ -41,10 +37,10 @@ func firstResponse(t *testing.T, entry *CompiledFlowNode) *CompiledFlowNode {
 // old walker found nothing and deferred public.
 func TestResponseBehindHandleIsFound(t *testing.T) {
 	entry := entryWith(nil, map[string][]*CompiledFlowNode{
-		"condition_1": {responseNode("ephemeral", true)},
+		"condition_1": {newResponseNode("ephemeral", true)},
 	})
 
-	found := firstResponse(t, entry)
+	found := firstResponse(entry)
 	if found == nil {
 		t.Fatal("response behind a handle was not found")
 	}
@@ -57,13 +53,13 @@ func TestResponseBehindHandleIsFound(t *testing.T) {
 // ephemerally, otherwise the defer forces the public reply ephemeral.
 func TestPublicFirstResponseWinsOverEphemeralBranch(t *testing.T) {
 	entry := entryWith(
-		[]*CompiledFlowNode{responseNode("public", false)},
+		[]*CompiledFlowNode{newResponseNode("public", false)},
 		map[string][]*CompiledFlowNode{
-			"condition_1": {responseNode("ephemeral", true)},
+			"condition_1": {newResponseNode("ephemeral", true)},
 		},
 	)
 
-	found := firstResponse(t, entry)
+	found := firstResponse(entry)
 	if found == nil {
 		t.Fatal("no response found")
 	}
@@ -74,13 +70,15 @@ func TestPublicFirstResponseWinsOverEphemeralBranch(t *testing.T) {
 
 // Direct children are reached before deeper ones.
 func TestDirectChildPreferredOverNested(t *testing.T) {
-	nested := entryWith([]*CompiledFlowNode{responseNode("deep", true)}, nil)
-	nested.ID = "nested"
-	nested.Type = FlowNodeTypeControlConditionCompare
+	nested := &CompiledFlowNode{
+		ID:       "nested",
+		Type:     FlowNodeTypeControlConditionCompare,
+		Children: ConnectedFlowNodes{Default: []*CompiledFlowNode{newResponseNode("deep", true)}},
+	}
 
-	entry := entryWith([]*CompiledFlowNode{nested, responseNode("shallow", false)}, nil)
+	entry := entryWith([]*CompiledFlowNode{nested, newResponseNode("shallow", false)}, nil)
 
-	found := firstResponse(t, entry)
+	found := firstResponse(entry)
 	if found == nil || found.ID != "shallow" {
 		t.Errorf("found %v, want the direct child", found)
 	}
@@ -91,15 +89,15 @@ func TestDirectChildPreferredOverNested(t *testing.T) {
 func TestHandleOrderIsStable(t *testing.T) {
 	build := func() *CompiledFlowNode {
 		return entryWith(nil, map[string][]*CompiledFlowNode{
-			"a_branch": {responseNode("a", false)},
-			"b_branch": {responseNode("b", true)},
-			"c_branch": {responseNode("c", true)},
+			"a_branch": {newResponseNode("a", false)},
+			"b_branch": {newResponseNode("b", true)},
+			"c_branch": {newResponseNode("c", true)},
 		})
 	}
 
-	want := firstResponse(t, build())
+	want := firstResponse(build())
 	for i := 0; i < 50; i++ {
-		if got := firstResponse(t, build()); got.ID != want.ID {
+		if got := firstResponse(build()); got.ID != want.ID {
 			t.Fatalf("iteration %d picked %q, want %q", i, got.ID, want.ID)
 		}
 	}
@@ -114,21 +112,21 @@ func TestNonResponseNodeIgnored(t *testing.T) {
 		Data: FlowNodeData{MessageEphemeral: true},
 	}}, nil)
 
-	if found := firstResponse(t, entry); found != nil {
+	if found := firstResponse(entry); found != nil {
 		t.Errorf("non-response node %q counted as a response", found.ID)
 	}
 }
 
 // Flows can loop back on themselves; the walk must terminate.
 func TestCycleTerminates(t *testing.T) {
-	a := &CompiledFlowNode{ID: "a", Children: ConnectedFlowNodes{Handles: map[string][]*CompiledFlowNode{}}}
-	b := &CompiledFlowNode{ID: "b", Children: ConnectedFlowNodes{Handles: map[string][]*CompiledFlowNode{}}}
+	a := &CompiledFlowNode{ID: "a"}
+	b := &CompiledFlowNode{ID: "b"}
 	a.Children.Default = []*CompiledFlowNode{b}
 	b.Children.Default = []*CompiledFlowNode{a}
 
 	entry := entryWith([]*CompiledFlowNode{a}, nil)
 
-	if found := firstResponse(t, entry); found != nil {
+	if found := firstResponse(entry); found != nil {
 		t.Errorf("unexpected match %q in a cyclic flow", found.ID)
 	}
 }

--- a/kite-service/pkg/flow/compile.go
+++ b/kite-service/pkg/flow/compile.go
@@ -2,6 +2,7 @@ package flow
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -628,4 +629,60 @@ func (n *CompiledFlowNode) findChildWithID(nodeID string, includeSubFlows bool, 
 	}
 
 	return nil
+}
+
+// FirstChildMatching returns the first node in the subtree satisfying match,
+// in the order the flow would reach them: direct children first, then deeper
+// ones. Handle keys are sorted so the result doesn't depend on Go's random
+// map iteration order.
+//
+// Unlike FindChildWithType this includes handle-based children, so nodes
+// behind condition branches and button handles are considered at all.
+func (n *CompiledFlowNode) FirstChildMatching(match func(*CompiledFlowNode) bool) *CompiledFlowNode {
+	return n.firstChildMatching(make(map[string]bool), match)
+}
+
+func (n *CompiledFlowNode) firstChildMatching(
+	visited map[string]bool,
+	match func(*CompiledFlowNode) bool,
+) *CompiledFlowNode {
+	if visited[n.ID] {
+		return nil
+	}
+	visited[n.ID] = true
+
+	children := n.orderedChildren()
+
+	for _, node := range children {
+		if match(node) {
+			return node
+		}
+	}
+
+	for _, node := range children {
+		if found := node.firstChildMatching(visited, match); found != nil {
+			return found
+		}
+	}
+
+	return nil
+}
+
+// orderedChildren lists default children followed by handle children, with
+// handle keys sorted for a stable order.
+func (n *CompiledFlowNode) orderedChildren() []*CompiledFlowNode {
+	children := make([]*CompiledFlowNode, 0, len(n.Children.Default))
+	children = append(children, n.Children.Default...)
+
+	handles := make([]string, 0, len(n.Children.Handles))
+	for handle := range n.Children.Handles {
+		handles = append(handles, handle)
+	}
+	sort.Strings(handles)
+
+	for _, handle := range handles {
+		children = append(children, n.Children.Handles[handle]...)
+	}
+
+	return children
 }

--- a/kite-service/pkg/flow/compile.go
+++ b/kite-service/pkg/flow/compile.go
@@ -2,7 +2,8 @@ package flow
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -538,37 +539,6 @@ func (n *CompiledFlowNode) FindDirectChildWithType(types ...FlowNodeType) *Compi
 	return nil
 }
 
-func (n *CompiledFlowNode) FindChildWithType(types ...FlowNodeType) *CompiledFlowNode {
-	return n.findChildWithType(make(map[string]bool), types...)
-}
-
-func (n *CompiledFlowNode) findChildWithType(visited map[string]bool, types ...FlowNodeType) *CompiledFlowNode {
-	// Mark this node as visited to prevent cycles
-	visited[n.ID] = true
-
-	// We first want to check all direct children
-	for _, node := range n.Children.Default {
-		for _, t := range types {
-			if node.Type == t {
-				return node
-			}
-		}
-	}
-
-	// If no direct children are found, we want to check all children recursively
-	for _, node := range n.Children.Default {
-		// Only recurse if we haven't visited this node before
-		if !visited[node.ID] {
-			child := node.findChildWithType(visited, types...)
-			if child != nil {
-				return child
-			}
-		}
-	}
-
-	return nil
-}
-
 func (n *CompiledFlowNode) FindParentWithID(id string) *CompiledFlowNode {
 	return n.findParentWithID(id, make(map[string]bool))
 }
@@ -636,8 +606,8 @@ func (n *CompiledFlowNode) findChildWithID(nodeID string, includeSubFlows bool, 
 // ones. Handle keys are sorted so the result doesn't depend on Go's random
 // map iteration order.
 //
-// Unlike FindChildWithType this includes handle-based children, so nodes
-// behind condition branches and button handles are considered at all.
+// Handle-based children are included, so nodes behind condition branches and
+// button handles are considered too.
 func (n *CompiledFlowNode) FirstChildMatching(match func(*CompiledFlowNode) bool) *CompiledFlowNode {
 	return n.firstChildMatching(make(map[string]bool), match)
 }
@@ -671,16 +641,10 @@ func (n *CompiledFlowNode) firstChildMatching(
 // orderedChildren lists default children followed by handle children, with
 // handle keys sorted for a stable order.
 func (n *CompiledFlowNode) orderedChildren() []*CompiledFlowNode {
-	children := make([]*CompiledFlowNode, 0, len(n.Children.Default))
+	children := make([]*CompiledFlowNode, 0, len(n.Children.Default)+len(n.Children.Handles))
 	children = append(children, n.Children.Default...)
 
-	handles := make([]string, 0, len(n.Children.Handles))
-	for handle := range n.Children.Handles {
-		handles = append(handles, handle)
-	}
-	sort.Strings(handles)
-
-	for _, handle := range handles {
+	for _, handle := range slices.Sorted(maps.Keys(n.Children.Handles)) {
 		children = append(children, n.Children.Handles[handle]...)
 	}
 

--- a/kite-service/pkg/flow/execute.go
+++ b/kite-service/pkg/flow/execute.go
@@ -195,8 +195,9 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 				interaction.Token,
 				discord.MessageID(messageTarget.Snowflake()),
 				api.EditInteractionResponseData{
-					Content: responseData.Content,
-					Embeds:  responseData.Embeds,
+					Content:    responseData.Content,
+					Embeds:     responseData.Embeds,
+					Components: responseData.Components,
 				},
 			)
 			if err != nil {
@@ -428,6 +429,9 @@ func (n *CompiledFlowNode) Execute(ctx *FlowContext) error {
 			api.EditMessageData{
 				Content: option.NewNullableString(messageData.Content),
 				Embeds:  &messageData.Embeds,
+				// Without this the edit silently drops the buttons, even
+				// though a resume point is created for them right below.
+				Components: &messageData.Components,
 			},
 		)
 		if err != nil {
@@ -1734,10 +1738,16 @@ func (n *CompiledFlowNode) autoDeferInteraction(ctx *FlowContext) error {
 		}
 	}
 
-	// We check if the next response will be ephemeral and adjust the defer flags accordingly
+	// The defer has to declare up front whether the response is ephemeral, so
+	// we guess from the first response the flow can reach. The guess only
+	// binds a response that edits the original; a followup carries its own
+	// flags either way.
+	//
+	// This can't be right for every flow — branches may disagree, and only one
+	// of them runs. Users who need certainty should defer explicitly instead.
 	var responseFlags discord.MessageFlags
-	respondeNode := n.FindChildWithType(FlowNodeTypeActionResponseCreate, FlowNodeTypeActionResponseEdit, FlowNodeTypeActionResponseDefer)
-	if respondeNode != nil && respondeNode.Data.MessageEphemeral {
+	responseNode := n.FirstChildMatching(isResponseNode)
+	if responseNode != nil && responseNode.Data.MessageEphemeral {
 		responseFlags |= discord.EphemeralMessage
 	}
 
@@ -1887,5 +1897,18 @@ func createDefaultErrorResponse(fCtx *FlowContext, err error) {
 			Type: api.MessageInteractionWithSource,
 			Data: &respData,
 		})
+	}
+}
+
+// isResponseNode reports whether a node responds to the interaction, and so
+// determines whether the deferred response is ephemeral.
+func isResponseNode(n *CompiledFlowNode) bool {
+	switch n.Type {
+	case FlowNodeTypeActionResponseCreate,
+		FlowNodeTypeActionResponseEdit,
+		FlowNodeTypeActionResponseDefer:
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
Follow-up to #324: fixes the fallout that PR made reachable, then works through the contained backend bugs.

Closes #251

---

### Fallout from #324 — assets when object storage is off

Making S3 optional left the asset path reachable without it, and it didn't degrade well:

- `CreateAsset` inserted the DB row **before** uploading, so any failed upload left a row pointing at content that was never stored. Every later read of that asset then breaks. Previously unreachable, because the server refused to boot without S3.
- The failure surfaced as a generic 500 `internal_error`.

Uploads now happen before the insert. Objects are content-addressed, so an upload with no row is harmless and reusable; the reverse is not. `ErrObjectStoreDisabled` is translated to a 503 `assets_disabled` on both create and download, so the user is told what's actually wrong.

The regression test passes a nil DB handle: if the insert ran first it would panic, so reaching a clean error proves the ordering.

### #251 — buttons and modals in event listeners

Resume points store `CommandID`, `EventListenerID` and `MessageInstanceID`, but dispatch only ever handled some of them: button interactions checked `CommandID` alone, modals checked `CommandID` and `MessageInstanceID`. A button or modal inside an event listener flow resolved to nothing and returned silently, which Discord shows as "This interaction failed".

Both call sites carried their own copy of the same resolve-and-execute block. They're now one owner-aware `resumeFlow`, with target resolution split into `resumeFlowTarget` so dispatch is testable without spawning goroutines. Net ~140 lines of duplication removed.

Side effect: buttons now also reach the message-instance case that only modals handled before.

This may also be the underlying cause of #282 and #299 — both are "This interaction failed" reports. Left open pending a retest from the reporters.

### #245 — auto-defer blind to branch responses

`FindChildWithType` only walks `Children.Default`. Condition branches and button handles live in `Children.Handles`, so a response behind either was **invisible** to the auto-defer, and the interaction deferred public even when its only response was ephemeral. It only bites when execution passes the 1.5s auto-defer threshold, which is why it looked random.

The walk now includes handle children. Handle keys are sorted — they're a Go map, so without that the same flow would defer differently between runs.

**Deliberately still a guess, and still not correct in general.** My first attempt promoted any flow containing an ephemeral response to an ephemeral defer, on the theory that the mistakes are asymmetric. They aren't, quite:

- `ActionResponseCreate` after a defer → `CreateInteractionFollowup`, which carries its own flags and is unaffected.
- `ActionResponseEdit` on `@original` → `EditInteractionResponse`, which **inherits the defer's flag**.

So for a flow whose first response is public with ephemeral followups, promoting would have forced the public reply ephemeral — a new failure mode. Reverted; it still guesses from the first reachable response, and there's a test pinning that case so it doesn't get re-introduced.

When branches genuinely disagree, no static guess is right: only one branch runs, and the flag is committed before we know which. The real answer is explicit deferral — `action_response_defer` already exists but isn't surfaced as the solution. Worth a UI nudge when a flow has mixed-ephemeral responses. #245 and #312 stay open for that reason.

### Components dropped on edit

`action_message_edit` and the non-`@original` interaction followup both sent only content and embeds — so buttons silently vanished on edit, while a resume point was still created for the components that were never sent. Both now send `Components`. (The message-template path via `ToEditMessageData` already did, so templates were never affected.)

Relevant to #278 and #271; not closing either, since neither is fully explained by this alone.

---

### Testing

- `go build ./...`, `go vet`, `go test ./...` — all pass.
- New tests: asset write ordering; resume dispatch for command / event-listener / unknown owners; auto-defer traversal including the public-first-with-ephemeral-branch case, handle-order stability, cycle termination.

**Not verified against real Discord.** The ephemeral behaviour in particular depends on server-side semantics I could only reason about from the API contract — worth a live check on a flow that exceeds the 1.5s defer threshold before merging.
