### PR TITLE
fix(eval): bound expression and template length

### DIFF
--- a/kite-service/pkg/eval/eval.go
+++ b/kite-service/pkg/eval/eval.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,9 +15,36 @@ import (
 const (
 	templateStartTag = "{{"
 	templateEndTag   = "}}"
+
+	// MaxExpressionLength bounds a single expression handed to expr.Compile.
+	// The compiler allocates AST nodes proportional to the input, so an
+	// unbounded expression lets a flow author exhaust memory at execution time.
+	//
+	// The value is deliberately loose. Closing the parser blowup only requires
+	// keeping input out of the megabytes, so anything in the low thousands would
+	// do; the limit is set well above realistic usage (Discord caps message
+	// content at 2000 and a whole embed at 6000) so that no flow already stored
+	// in the database starts failing at runtime.
+	MaxExpressionLength = 10_000
+
+	// MaxTemplateLength bounds a whole template before its placeholders are
+	// evaluated. Each placeholder is bounded by MaxExpressionLength, but a
+	// template may contain arbitrarily many of them.
+	MaxTemplateLength = 100_000
 )
 
+// ErrExpressionTooLong is returned when an expression or template exceeds its
+// length limit. Flows are user-authored, so this is reachable from user input.
+var ErrExpressionTooLong = errors.New("expression too long")
+
 func Eval(ctx context.Context, expression string, c Context) (thing.Thing, error) {
+	if len(expression) > MaxExpressionLength {
+		return thing.Null, fmt.Errorf(
+			"eval error: %w: %d characters, limit is %d",
+			ErrExpressionTooLong, len(expression), MaxExpressionLength,
+		)
+	}
+
 	c.Env["ctx"] = proxyContext{ctx: ctx}
 
 	opts := []expr.Option{
@@ -44,6 +72,13 @@ func Eval(ctx context.Context, expression string, c Context) (thing.Thing, error
 }
 
 func EvalTemplate(ctx context.Context, template string, c Context) (thing.Thing, error) {
+	if len(template) > MaxTemplateLength {
+		return thing.Null, fmt.Errorf(
+			"eval error: %w: %d characters, limit is %d",
+			ErrExpressionTooLong, len(template), MaxTemplateLength,
+		)
+	}
+
 	template = strings.TrimSpace(template)
 	if template == "" {
 		return thing.Null, nil

--- a/kite-service/pkg/eval/eval_test.go
+++ b/kite-service/pkg/eval/eval_test.go
@@ -1,0 +1,124 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func testContext() Context {
+	return Context{Env: map[string]any{}}
+}
+
+func TestEvalRejectsOverlongExpression(t *testing.T) {
+	// A long chain of additions is valid syntax, so it reaches expr.Compile
+	// unless the length bound stops it first.
+	expression := "1" + strings.Repeat("+1", MaxExpressionLength)
+
+	_, err := Eval(context.Background(), expression, testContext())
+	if err == nil {
+		t.Fatal("expected error for overlong expression, got nil")
+	}
+	if !errors.Is(err, ErrExpressionTooLong) {
+		t.Fatalf("expected ErrExpressionTooLong, got %v", err)
+	}
+}
+
+func TestEvalAllowsExpressionAtLimit(t *testing.T) {
+	// Padding with spaces keeps the expression trivial to compile while landing
+	// exactly on the limit, so we verify the boundary is inclusive.
+	expression := "1" + strings.Repeat(" ", MaxExpressionLength-1)
+	if len(expression) != MaxExpressionLength {
+		t.Fatalf("setup: got length %d, want %d", len(expression), MaxExpressionLength)
+	}
+
+	res, err := Eval(context.Background(), expression, testContext())
+	if err != nil {
+		t.Fatalf("expected expression at limit to be accepted, got %v", err)
+	}
+	if res.String() != "1" {
+		t.Errorf("got %q, want %q", res.String(), "1")
+	}
+}
+
+func TestEvalTemplateRejectsOverlongTemplate(t *testing.T) {
+	template := strings.Repeat("a", MaxTemplateLength+1)
+
+	_, err := EvalTemplate(context.Background(), template, testContext())
+	if err == nil {
+		t.Fatal("expected error for overlong template, got nil")
+	}
+	if !errors.Is(err, ErrExpressionTooLong) {
+		t.Fatalf("expected ErrExpressionTooLong, got %v", err)
+	}
+}
+
+func TestEvalTemplateRejectsOverlongPlaceholder(t *testing.T) {
+	// The template itself is under MaxTemplateLength, but the placeholder inside
+	// it exceeds MaxExpressionLength, so the bound in Eval must catch it.
+	inner := "1" + strings.Repeat("+1", MaxExpressionLength)
+	template := "prefix {{" + inner + "}} suffix"
+	if len(template) > MaxTemplateLength {
+		t.Fatalf("setup: template length %d exceeds MaxTemplateLength", len(template))
+	}
+
+	_, err := EvalTemplate(context.Background(), template, testContext())
+	if err == nil {
+		t.Fatal("expected error for overlong placeholder, got nil")
+	}
+	if !errors.Is(err, ErrExpressionTooLong) {
+		t.Fatalf("expected ErrExpressionTooLong, got %v", err)
+	}
+}
+
+// The single-placeholder fast path in EvalTemplate strips the delimiters and
+// calls Eval directly, bypassing fasttemplate, so it needs its own coverage.
+func TestEvalTemplateRejectsOverlongSinglePlaceholder(t *testing.T) {
+	inner := "1" + strings.Repeat("+1", MaxExpressionLength)
+	template := "{{" + inner + "}}"
+	if len(template) > MaxTemplateLength {
+		t.Fatalf("setup: template length %d exceeds MaxTemplateLength", len(template))
+	}
+
+	_, err := EvalTemplate(context.Background(), template, testContext())
+	if err == nil {
+		t.Fatal("expected error for overlong single placeholder, got nil")
+	}
+	if !errors.Is(err, ErrExpressionTooLong) {
+		t.Fatalf("expected ErrExpressionTooLong, got %v", err)
+	}
+}
+
+// Ordinary expressions must keep working; the bound is far above real usage.
+func TestEvalAcceptsNormalExpressions(t *testing.T) {
+	cases := []struct{ expression, want string }{
+		{`1 + 2`, "3"},
+		{`"a" + "b"`, "ab"},
+		{`[1,2,3] | filter(# > 1) | len()`, "2"},
+		{`max([1,5,3])`, "5"},
+		{`upper("hi")`, "HI"},
+		{`true ? "y" : "n"`, "y"},
+	}
+
+	for _, c := range cases {
+		res, err := Eval(context.Background(), c.expression, testContext())
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", c.expression, err)
+			continue
+		}
+		if res.String() != c.want {
+			t.Errorf("%s: got %q, want %q", c.expression, res.String(), c.want)
+		}
+	}
+}
+
+func TestEvalTemplateAcceptsNormalTemplates(t *testing.T) {
+	res, err := EvalTemplate(context.Background(), `hello {{ "world" }}`, testContext())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.String() != "hello world" {
+		t.Errorf("got %q, want %q", res.String(), "hello world")
+	}
+}

--- a/kite-service/pkg/flow/data.go
+++ b/kite-service/pkg/flow/data.go
@@ -277,6 +277,13 @@ func (d FlowNodeData) Validate(nodeType FlowNodeType) error {
 		validation.Field(&d.AIChatCompletionData, validation.When(nodeType == FlowNodeTypeActionAIChatCompletion,
 			validation.Required,
 		)),
+
+		// Expression Evaluate
+		// Bounded for every node type rather than just entry nodes: an oversized
+		// expression is a resource-exhaustion risk at execution time, not just a
+		// correctness problem. eval enforces the same limit as a backstop for
+		// flows stored before this check existed.
+		validation.Field(&d.Expression, validation.Length(0, eval.MaxExpressionLength)),
 	)
 }
 


### PR DESCRIPTION
Follow-up to #326. That PR upgraded `expr` to 1.17.7, which fixes the parser blowup upstream; this adds the input bound so the exposure is closed at our layer too.

## Why

`pkg/eval/eval.go` hands flow expressions straight to `expr.Compile`, which allocates AST nodes proportional to input size. Flows are user-authored, so an oversized expression was a memory-exhaustion vector at execution time.

## Where the check goes

Enforced in `pkg/eval`, not only at the API boundary. `Eval` is the single choke point every template path routes through (`EvalTemplate`, its single-placeholder fast path, and `EvalTemplateToString` all funnel into it), so one check covers every caller — **including flows already stored in the database**, which an API-only check would miss.

`FlowNodeData.Validate` additionally bounds the `Expression` field so new writes fail at save time with a clear error rather than at execution. That one is applied to all node types rather than just entry nodes, deliberately: the surrounding code only validates entry nodes because semantic validity is less critical elsewhere, but this is a resource bound, and the risk doesn't depend on node type.

## On the values

`MaxExpressionLength = 10_000`, `MaxTemplateLength = 100_000` — deliberately loose, and worth being explicit since these sit above the codebase's other bounds (the largest is `Length(1, 2000)` on the AI `Prompt`; everything else is ≤255).

Closing the blowup only requires keeping input out of the megabytes, so anything in the low thousands would work equally well for security. The values are set far above realistic usage — Discord caps message content at 2,000 and a whole embed at 6,000, and message fields are evaluated as separate templates — so that **no flow already in the database starts failing at runtime**. Tightening to ~2,000 would match convention better at the cost of that risk; the reasoning is recorded in a comment on the constants if you want to revisit.

## Tests

New `pkg/eval/eval_test.go` — the package had no tests before.

- Rejects overlong expression, template, and placeholder-within-template
- Covers the single-placeholder fast path separately, since it strips delimiters and calls `Eval` directly, bypassing `fasttemplate`
- Asserts the boundary is inclusive (an expression exactly at the limit is accepted)
- Regression cases for ordinary expressions (arithmetic, pipes, `filter`, `max`, ternary, template interpolation)

`go build ./...`, `go test ./...`, and `gofmt` all clean.

## Note

Separately, the API has no request body size limit at all (no `http.MaxBytesReader` anywhere in `internal/`). Out of scope here, but worth its own look — it bounds the whole class of oversized-payload issues rather than just this one.