### PR TITLE
fix: scope engine data access to the executing app

### DIFF
--- a/kite-service/internal/api/access/middleware.go
+++ b/kite-service/internal/api/access/middleware.go
@@ -93,17 +93,15 @@ func (m *AccessManager) MessageAccess(next handler.HandlerFunc) handler.HandlerF
 		messageID := c.Param("messageID")
 		appID := c.Param("appID")
 
-		message, err := m.messageStore.Message(c.Context(), messageID)
+		// Scoped by app in the query rather than compared afterwards, so a
+		// message belonging to another app is indistinguishable from one that
+		// does not exist. AppAccess has already established access to appID.
+		message, err := m.messageStore.Message(c.Context(), appID, messageID)
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
 				return handler.ErrNotFound("unknown_message", "Message not found")
 			}
 			return err
-		}
-
-		// We assume that app access has already been checked
-		if message.AppID != appID {
-			return handler.ErrForbidden("missing_access", "Access to message missing")
 		}
 
 		c.Message = message

--- a/kite-service/internal/api/handler/message/instances.go
+++ b/kite-service/internal/api/handler/message/instances.go
@@ -46,7 +46,7 @@ func (h *MessageHandler) HandleMessageInstanceCreate(c *handler.Context, req wir
 		return nil, fmt.Errorf("failed to send message: %w", err)
 	}
 
-	instance, err := h.messageInstanceStore.CreateMessageInstance(c.Context(), &model.MessageInstance{
+	instance, err := h.messageInstanceStore.CreateMessageInstance(c.Context(), c.App.ID, &model.MessageInstance{
 		MessageID:        c.Message.ID,
 		DiscordGuildID:   req.DiscordGuildID,
 		DiscordChannelID: req.DiscordChannelID,

--- a/kite-service/internal/api/handler/message/instances.go
+++ b/kite-service/internal/api/handler/message/instances.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (h *MessageHandler) HandleMessageInstanceList(c *handler.Context) (*wire.MessageInstanceListResponse, error) {
-	instances, err := h.messageInstanceStore.MessageInstancesByMessage(c.Context(), c.Message.ID, false)
+	instances, err := h.messageInstanceStore.MessageInstancesByMessage(c.Context(), c.App.ID, c.Message.ID, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get message instances: %w", err)
 	}
@@ -65,7 +65,7 @@ func (h *MessageHandler) HandleMessageInstanceCreate(c *handler.Context, req wir
 func (h *MessageHandler) HandleMessageInstanceUpdate(c *handler.Context) (*wire.MessageInstanceUpdateResponse, error) {
 	instanceID, _ := strconv.ParseUint(c.Param("instanceID"), 10, 64)
 
-	instance, err := h.messageInstanceStore.MessageInstance(c.Context(), c.Message.ID, instanceID)
+	instance, err := h.messageInstanceStore.MessageInstance(c.Context(), c.App.ID, c.Message.ID, instanceID)
 	if err != nil {
 		if err == store.ErrNotFound {
 			return nil, handler.ErrNotFound("message_instance_not_found", "message instance not found")
@@ -93,7 +93,7 @@ func (h *MessageHandler) HandleMessageInstanceUpdate(c *handler.Context) (*wire.
 		return nil, fmt.Errorf("failed to edit message: %w", err)
 	}
 
-	instance, err = h.messageInstanceStore.UpdateMessageInstance(c.Context(), &model.MessageInstance{
+	instance, err = h.messageInstanceStore.UpdateMessageInstance(c.Context(), c.App.ID, &model.MessageInstance{
 		ID:          instance.ID,
 		MessageID:   instance.MessageID,
 		FlowSources: c.Message.FlowSources,
@@ -109,7 +109,7 @@ func (h *MessageHandler) HandleMessageInstanceUpdate(c *handler.Context) (*wire.
 func (h *MessageHandler) HandleMessageInstanceDelete(c *handler.Context) (*wire.MessageInstanceDeleteResponse, error) {
 	instanceID, _ := strconv.ParseUint(c.Param("instanceID"), 10, 64)
 
-	err := h.messageInstanceStore.DeleteMessageInstance(c.Context(), c.Message.ID, instanceID)
+	err := h.messageInstanceStore.DeleteMessageInstance(c.Context(), c.App.ID, c.Message.ID, instanceID)
 	if err != nil {
 		if err == store.ErrNotFound {
 			return nil, handler.ErrNotFound("message_instance_not_found", "message instance not found")

--- a/kite-service/internal/api/handler/variable/handler.go
+++ b/kite-service/internal/api/handler/variable/handler.go
@@ -107,7 +107,7 @@ func (h *VariableHandler) HandleVariablesImport(c *handler.Context, req wire.Var
 func (h *VariableHandler) HandleVariableUpdate(c *handler.Context, req wire.VariableUpdateRequest) (*wire.VariableUpdateResponse, error) {
 	if req.Scoped != c.Variable.Scoped {
 		// If the scoped flag changes, delete all variable values.
-		err := h.variableValueStore.DeleteAllVariableValues(c.Context(), c.Variable.ID)
+		err := h.variableValueStore.DeleteAllVariableValues(c.Context(), c.App.ID, c.Variable.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to delete variable values: %w", err)
 		}

--- a/kite-service/internal/api/wire/message.go
+++ b/kite-service/internal/api/wire/message.go
@@ -53,6 +53,7 @@ func (req MessageCreateRequest) Validate() error {
 	return validation.ValidateStruct(&req,
 		validation.Field(&req.Name, validation.Required, validation.Length(1, 100)),
 		validation.Field(&req.Description, validation.Length(0, 255)),
+		validation.Field(&req.Data),
 	)
 }
 
@@ -102,6 +103,7 @@ func (req MessageUpdateRequest) Validate() error {
 	return validation.ValidateStruct(&req,
 		validation.Field(&req.Name, validation.Required, validation.Length(1, 100)),
 		validation.Field(&req.Description, validation.Length(0, 255)),
+		validation.Field(&req.Data),
 	)
 }
 

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -250,7 +250,7 @@ func (a *App) HandleEvent(appID string, session *state.State, event gateway.Even
 			}
 
 			messageID := e.Message.ID.String()
-			messageInstnace, err := a.env.MessageInstanceStore.MessageInstanceByDiscordMessageID(context.TODO(), messageID)
+			messageInstnace, err := a.env.MessageInstanceStore.MessageInstanceByDiscordMessageID(context.TODO(), a.id, messageID)
 			if err != nil {
 				if errors.Is(err, store.ErrNotFound) {
 					return
@@ -319,6 +319,22 @@ func (a *App) resumeFlow(
 		return
 	}
 
+	// The ID arrives in an interaction's custom_id, which is chosen by whoever
+	// built the message rather than by us, so it is not proof that the resume
+	// point belongs to this app. The command and event listener branches below
+	// fail closed anyway because they resolve against this app's own in-memory
+	// maps, but the message instance branch reads from the database and would
+	// otherwise run another app's flow -- with its stored FlowState, which
+	// holds the results of everything the flow did before it suspended.
+	if resumePoint.AppID != a.id {
+		slog.Warn(
+			"Resume point does not belong to this app",
+			slog.String("app_id", a.id),
+			slog.String("resume_point_id", resumePointID),
+		)
+		return
+	}
+
 	targetFlow := a.resumeFlowTarget(resumePoint)
 	if targetFlow == nil {
 		return
@@ -383,6 +399,7 @@ func (a *App) resumeFlowTarget(resumePoint *model.ResumePoint) *flow.CompiledFlo
 	case resumePoint.MessageInstanceID.Valid:
 		messageInstance, err := a.env.MessageInstanceStore.MessageInstance(
 			context.TODO(),
+			a.id,
 			resumePoint.MessageID.String,
 			uint64(resumePoint.MessageInstanceID.Int64),
 		)

--- a/kite-service/internal/core/engine/app.go
+++ b/kite-service/internal/core/engine/app.go
@@ -307,7 +307,13 @@ func (a *App) resumeFlow(
 	session *state.State,
 	event gateway.Event,
 ) {
-	resumePoint, err := a.env.ResumePointStore.ResumePoint(context.TODO(), resumePointID)
+	// The ID arrives in an interaction's custom_id, which is chosen by whoever
+	// built the message rather than by us, so it is not proof that the resume
+	// point belongs to this app -- hence the scoped lookup. Without it the
+	// message instance branch below would read another app's resume point out
+	// of the database and run its flow, with its stored FlowState, which holds
+	// the results of everything that flow did before it suspended.
+	resumePoint, err := a.env.ResumePointStore.ResumePoint(context.TODO(), a.id, resumePointID)
 	if err != nil {
 		if !errors.Is(err, store.ErrNotFound) {
 			slog.Error(
@@ -316,22 +322,6 @@ func (a *App) resumeFlow(
 				slog.String("error", err.Error()),
 			)
 		}
-		return
-	}
-
-	// The ID arrives in an interaction's custom_id, which is chosen by whoever
-	// built the message rather than by us, so it is not proof that the resume
-	// point belongs to this app. The command and event listener branches below
-	// fail closed anyway because they resolve against this app's own in-memory
-	// maps, but the message instance branch reads from the database and would
-	// otherwise run another app's flow -- with its stored FlowState, which
-	// holds the results of everything the flow did before it suspended.
-	if resumePoint.AppID != a.id {
-		slog.Warn(
-			"Resume point does not belong to this app",
-			slog.String("app_id", a.id),
-			slog.String("resume_point_id", resumePointID),
-		)
 		return
 	}
 

--- a/kite-service/internal/core/engine/helpers.go
+++ b/kite-service/internal/core/engine/helpers.go
@@ -64,8 +64,8 @@ func (s Env) flowProviders(appID string, session *state.State, links entityLinks
 		),
 		HTTP:            NewHTTPProvider(s.HttpClient),
 		AI:              aiProvider,
-		MessageTemplate: NewMessageTemplateProvider(s.MessageStore, s.MessageInstanceStore),
-		Variable:        NewVariableProvider(s.VariableValueStore),
+		MessageTemplate: NewMessageTemplateProvider(appID, s.MessageStore, s.MessageInstanceStore),
+		Variable:        NewVariableProvider(appID, s.VariableValueStore),
 		ResumePoint: NewResumePointProvider(
 			s.ResumePointStore,
 			appID,

--- a/kite-service/internal/core/engine/providers.go
+++ b/kite-service/internal/core/engine/providers.go
@@ -633,7 +633,7 @@ func (p *MessageTemplateProvider) LinkMessageTemplateInstance(ctx context.Contex
 		return fmt.Errorf("failed to get message: %w", err)
 	}
 
-	_, err = p.messageInstanceStore.CreateMessageInstance(ctx, &model.MessageInstance{
+	_, err = p.messageInstanceStore.CreateMessageInstance(ctx, p.appID, &model.MessageInstance{
 		MessageID:        message.ID,
 		DiscordMessageID: instance.MessageID.String(),
 		DiscordChannelID: instance.ChannelID.String(),

--- a/kite-service/internal/core/engine/providers.go
+++ b/kite-service/internal/core/engine/providers.go
@@ -542,12 +542,20 @@ func (p *AIProvider) CreateResponse(ctx context.Context, opts provider.CreateRes
 	return resp.OutputText(), nil
 }
 
+// VariableProvider resolves the variable IDs a flow node names.
+//
+// Those IDs come from flow JSON the tenant authored, so the provider carries
+// the executing app's ID and passes it to every store call. Without it a flow
+// could name any variable ID in the database -- and flow JSON moves between
+// apps through import/export, so the IDs are not private.
 type VariableProvider struct {
+	appID              string
 	variableValueStore store.VariableValueStore
 }
 
-func NewVariableProvider(variableValueStore store.VariableValueStore) *VariableProvider {
+func NewVariableProvider(appID string, variableValueStore store.VariableValueStore) *VariableProvider {
 	return &VariableProvider{
+		appID:              appID,
 		variableValueStore: variableValueStore,
 	}
 }
@@ -561,7 +569,7 @@ func (p *VariableProvider) UpdateVariable(ctx context.Context, id string, scope 
 		UpdatedAt:  time.Now().UTC(),
 	}
 
-	newValue, err := p.variableValueStore.UpdateVariableValue(ctx, operation, v)
+	newValue, err := p.variableValueStore.UpdateVariableValue(ctx, p.appID, operation, v)
 	if err != nil {
 		return thing.Null, fmt.Errorf("failed to %s variable value: %w", operation, err)
 	}
@@ -570,7 +578,7 @@ func (p *VariableProvider) UpdateVariable(ctx context.Context, id string, scope 
 }
 
 func (p *VariableProvider) Variable(ctx context.Context, id string, scope null.String) (thing.Thing, error) {
-	row, err := p.variableValueStore.VariableValue(ctx, id, scope)
+	row, err := p.variableValueStore.VariableValue(ctx, p.appID, id, scope)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return thing.Null, provider.ErrNotFound
@@ -582,7 +590,7 @@ func (p *VariableProvider) Variable(ctx context.Context, id string, scope null.S
 }
 
 func (p *VariableProvider) DeleteVariable(ctx context.Context, id string, scope null.String) error {
-	err := p.variableValueStore.DeleteVariableValue(ctx, id, scope)
+	err := p.variableValueStore.DeleteVariableValue(ctx, p.appID, id, scope)
 	if err != nil {
 		return fmt.Errorf("failed to delete variable value: %w", err)
 	}
@@ -590,20 +598,28 @@ func (p *VariableProvider) DeleteVariable(ctx context.Context, id string, scope 
 	return nil
 }
 
+// MessageTemplateProvider resolves the message template a flow node names.
+//
+// Like VariableProvider, the ID comes from tenant-authored flow JSON, so the
+// provider carries the executing app's ID. Without it a flow could render
+// another tenant's template, and LinkMessageTemplateInstance would go on to
+// write an instance row against their message carrying their flow sources.
 type MessageTemplateProvider struct {
+	appID                string
 	messageStore         store.MessageStore
 	messageInstanceStore store.MessageInstanceStore
 }
 
-func NewMessageTemplateProvider(messageStore store.MessageStore, messageInstanceStore store.MessageInstanceStore) *MessageTemplateProvider {
+func NewMessageTemplateProvider(appID string, messageStore store.MessageStore, messageInstanceStore store.MessageInstanceStore) *MessageTemplateProvider {
 	return &MessageTemplateProvider{
+		appID:                appID,
 		messageStore:         messageStore,
 		messageInstanceStore: messageInstanceStore,
 	}
 }
 
 func (p *MessageTemplateProvider) MessageTemplate(ctx context.Context, id string) (*message.MessageData, error) {
-	message, err := p.messageStore.Message(ctx, id)
+	message, err := p.messageStore.Message(ctx, p.appID, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get message: %w", err)
 	}
@@ -612,7 +628,7 @@ func (p *MessageTemplateProvider) MessageTemplate(ctx context.Context, id string
 }
 
 func (p *MessageTemplateProvider) LinkMessageTemplateInstance(ctx context.Context, instance provider.MessageTemplateInstance) error {
-	message, err := p.messageStore.Message(ctx, instance.MessageTemplateID)
+	message, err := p.messageStore.Message(ctx, p.appID, instance.MessageTemplateID)
 	if err != nil {
 		return fmt.Errorf("failed to get message: %w", err)
 	}

--- a/kite-service/internal/core/engine/resume_test.go
+++ b/kite-service/internal/core/engine/resume_test.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kitecloud/kite/kite-service/internal/model"
+	"github.com/kitecloud/kite/kite-service/internal/store"
+	"gopkg.in/guregu/null.v4"
+)
+
+// A resume point ID arrives in an interaction's custom_id, which is chosen by
+// whoever built the message rather than by us. The message instance branch of
+// resumeFlowTarget reads from the database, so without an ownership check an
+// app can resume another app's flow -- including its stored FlowState.
+
+type stubResumePointStore struct {
+	point *model.ResumePoint
+}
+
+func (s stubResumePointStore) ResumePoint(ctx context.Context, id string) (*model.ResumePoint, error) {
+	return s.point, nil
+}
+
+func (s stubResumePointStore) CreateResumePoint(ctx context.Context, resumePoint *model.ResumePoint) error {
+	return nil
+}
+
+func (s stubResumePointStore) DeleteResumePoint(ctx context.Context, id string) error {
+	return nil
+}
+
+func (s stubResumePointStore) DeleteExpiredResumePoints(ctx context.Context, timestamp time.Time) error {
+	return nil
+}
+
+func messageInstanceResumePoint(appID string) *model.ResumePoint {
+	return &model.ResumePoint{
+		ID:                "rp-1",
+		Type:              model.ResumePointTypeMessageComponents,
+		AppID:             appID,
+		MessageID:         null.StringFrom("msg-1"),
+		MessageInstanceID: null.IntFrom(1),
+		FlowSourceID:      null.StringFrom("src-1"),
+		FlowNodeID:        "node-1",
+	}
+}
+
+func resumeApp(t *testing.T, resumePointAppID string) *App {
+	t.Helper()
+
+	// MessageInstanceStore is deliberately nil: reaching it is what the tests
+	// below distinguish on, the same trick store_asset_test.go uses.
+	return NewApp("app-1", Env{
+		ResumePointStore: stubResumePointStore{
+			point: messageInstanceResumePoint(resumePointAppID),
+		},
+	})
+}
+
+func TestResumeFlowIgnoresResumePointFromAnotherApp(t *testing.T) {
+	app := resumeApp(t, "app-2")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("a foreign resume point reached the message instance store: %v", r)
+		}
+	}()
+
+	app.resumeFlow("rp-1", nil, nil)
+}
+
+// The negative control: with a matching app the same call has to get past the
+// ownership check and reach the store, or the test above proves nothing.
+func TestResumeFlowResolvesOwnResumePoint(t *testing.T) {
+	app := resumeApp(t, "app-1")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected the app's own resume point to reach the message instance store")
+		}
+	}()
+
+	app.resumeFlow("rp-1", nil, nil)
+}
+
+var _ store.ResumePointStore = stubResumePointStore{}

--- a/kite-service/internal/core/engine/resume_test.go
+++ b/kite-service/internal/core/engine/resume_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/kitecloud/kite/kite-service/internal/model"
 	"github.com/kitecloud/kite/kite-service/internal/store"
@@ -12,27 +11,26 @@ import (
 
 // A resume point ID arrives in an interaction's custom_id, which is chosen by
 // whoever built the message rather than by us. The message instance branch of
-// resumeFlowTarget reads from the database, so without an ownership check an
-// app can resume another app's flow -- including its stored FlowState.
+// resumeFlowTarget reads from the database, so without app scoping on the
+// lookup an app can resume another app's flow -- including its stored
+// FlowState.
 
+// The embedded interface is left nil so that any method resumeFlow does not
+// call panics rather than silently returning a zero value, the same trick
+// engine_test.go uses.
 type stubResumePointStore struct {
+	store.ResumePointStore
+
 	point *model.ResumePoint
 }
 
-func (s stubResumePointStore) ResumePoint(ctx context.Context, id string) (*model.ResumePoint, error) {
+// Stands in for the query's `AND app_id = $2`: a point owned by another app is
+// indistinguishable from one that does not exist.
+func (s stubResumePointStore) ResumePoint(ctx context.Context, appID string, id string) (*model.ResumePoint, error) {
+	if s.point.AppID != appID {
+		return nil, store.ErrNotFound
+	}
 	return s.point, nil
-}
-
-func (s stubResumePointStore) CreateResumePoint(ctx context.Context, resumePoint *model.ResumePoint) error {
-	return nil
-}
-
-func (s stubResumePointStore) DeleteResumePoint(ctx context.Context, id string) error {
-	return nil
-}
-
-func (s stubResumePointStore) DeleteExpiredResumePoints(ctx context.Context, timestamp time.Time) error {
-	return nil
 }
 
 func messageInstanceResumePoint(appID string) *model.ResumePoint {
@@ -84,5 +82,3 @@ func TestResumeFlowResolvesOwnResumePoint(t *testing.T) {
 
 	app.resumeFlow("rp-1", nil, nil)
 }
-
-var _ store.ResumePointStore = stubResumePointStore{}

--- a/kite-service/internal/core/event/message_delete.go
+++ b/kite-service/internal/core/event/message_delete.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *EventHandlerWrapper) HandleMessageDeleteEvent(appID string, session *state.State, event *gateway.MessageDeleteEvent) {
-	err := h.messageInstanceStore.DeleteMessageInstanceByDiscordMessageID(context.Background(), event.ID.String())
+	err := h.messageInstanceStore.DeleteMessageInstanceByDiscordMessageID(context.Background(), appID, event.ID.String())
 	if err != nil && err != store.ErrNotFound {
 		slog.With("error", err).Error("failed to delete message instance from message delete event")
 	}

--- a/kite-service/internal/db/postgres/pgmodel/messages.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/messages.sql.go
@@ -82,6 +82,7 @@ func (q *Queries) CreateMessage(ctx context.Context, arg CreateMessageParams) (M
 }
 
 const createMessageInstance = `-- name: CreateMessageInstance :one
+
 INSERT INTO message_instances (
     message_id,
     discord_guild_id,
@@ -92,9 +93,10 @@ INSERT INTO message_instances (
     flow_sources,
     created_at,
     updated_at
-) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9
-) RETURNING id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at
+)
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+FROM messages WHERE messages.id = $1 AND messages.app_id = $10
+RETURNING id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at
 `
 
 type CreateMessageInstanceParams struct {
@@ -107,8 +109,15 @@ type CreateMessageInstanceParams struct {
 	FlowSources      []byte
 	CreatedAt        pgtype.Timestamp
 	UpdatedAt        pgtype.Timestamp
+	AppID            string
 }
 
+// message_instances has no app_id of its own, so the queries below reach the app
+// through messages. The engine reaches these from Discord interactions, where
+// the message and instance IDs are supplied by whoever clicked.
+// INSERT ... SELECT rather than VALUES so the app check is part of the write:
+// if the message does not belong to the app the select is empty, nothing is
+// inserted, and :one surfaces it as ErrNoRows.
 func (q *Queries) CreateMessageInstance(ctx context.Context, arg CreateMessageInstanceParams) (MessageInstance, error) {
 	row := q.db.QueryRow(ctx, createMessageInstance,
 		arg.MessageID,
@@ -120,6 +129,7 @@ func (q *Queries) CreateMessageInstance(ctx context.Context, arg CreateMessageIn
 		arg.FlowSources,
 		arg.CreatedAt,
 		arg.UpdatedAt,
+		arg.AppID,
 	)
 	var i MessageInstance
 	err := row.Scan(
@@ -214,7 +224,6 @@ func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (Message
 }
 
 const getMessageInstance = `-- name: GetMessageInstance :one
-
 SELECT message_instances.id, message_instances.message_id, message_instances.hidden, message_instances.ephemeral, message_instances.discord_guild_id, message_instances.discord_channel_id, message_instances.discord_message_id, message_instances.flow_sources, message_instances.created_at, message_instances.updated_at FROM message_instances
 JOIN messages ON messages.id = message_instances.message_id
 WHERE message_instances.id = $1
@@ -228,9 +237,6 @@ type GetMessageInstanceParams struct {
 	AppID     string
 }
 
-// message_instances has no app_id of its own, so the queries below join through
-// messages to scope by app. The engine reaches these from Discord interactions,
-// where the message and instance IDs are supplied by whoever clicked.
 func (q *Queries) GetMessageInstance(ctx context.Context, arg GetMessageInstanceParams) (MessageInstance, error) {
 	row := q.db.QueryRow(ctx, getMessageInstance, arg.ID, arg.MessageID, arg.AppID)
 	var i MessageInstance

--- a/kite-service/internal/db/postgres/pgmodel/messages.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/messages.sql.go
@@ -147,34 +147,56 @@ func (q *Queries) DeleteMessage(ctx context.Context, id string) error {
 }
 
 const deleteMessageInstance = `-- name: DeleteMessageInstance :exec
-DELETE FROM message_instances WHERE id = $1 AND message_id = $2
+DELETE FROM message_instances
+USING messages
+WHERE messages.id = message_instances.message_id
+  AND message_instances.id = $1
+  AND message_instances.message_id = $2
+  AND messages.app_id = $3
 `
 
 type DeleteMessageInstanceParams struct {
 	ID        int64
 	MessageID string
+	AppID     string
 }
 
 func (q *Queries) DeleteMessageInstance(ctx context.Context, arg DeleteMessageInstanceParams) error {
-	_, err := q.db.Exec(ctx, deleteMessageInstance, arg.ID, arg.MessageID)
+	_, err := q.db.Exec(ctx, deleteMessageInstance, arg.ID, arg.MessageID, arg.AppID)
 	return err
 }
 
 const deleteMessageInstanceByDiscordMessageId = `-- name: DeleteMessageInstanceByDiscordMessageId :exec
-DELETE FROM message_instances WHERE discord_message_id = $1
+DELETE FROM message_instances
+USING messages
+WHERE messages.id = message_instances.message_id
+  AND message_instances.discord_message_id = $1
+  AND messages.app_id = $2
 `
 
-func (q *Queries) DeleteMessageInstanceByDiscordMessageId(ctx context.Context, discordMessageID string) error {
-	_, err := q.db.Exec(ctx, deleteMessageInstanceByDiscordMessageId, discordMessageID)
+type DeleteMessageInstanceByDiscordMessageIdParams struct {
+	DiscordMessageID string
+	AppID            string
+}
+
+func (q *Queries) DeleteMessageInstanceByDiscordMessageId(ctx context.Context, arg DeleteMessageInstanceByDiscordMessageIdParams) error {
+	_, err := q.db.Exec(ctx, deleteMessageInstanceByDiscordMessageId, arg.DiscordMessageID, arg.AppID)
 	return err
 }
 
 const getMessage = `-- name: GetMessage :one
-SELECT id, name, description, data, flow_sources, app_id, module_id, creator_user_id, created_at, updated_at FROM messages WHERE id = $1
+SELECT id, name, description, data, flow_sources, app_id, module_id, creator_user_id, created_at, updated_at FROM messages WHERE id = $1 AND app_id = $2
 `
 
-func (q *Queries) GetMessage(ctx context.Context, id string) (Message, error) {
-	row := q.db.QueryRow(ctx, getMessage, id)
+type GetMessageParams struct {
+	ID    string
+	AppID string
+}
+
+// Scoped by app: the message ID reaches the engine from flow node config that
+// the tenant authored, so an ID on its own is not proof of ownership.
+func (q *Queries) GetMessage(ctx context.Context, arg GetMessageParams) (Message, error) {
+	row := q.db.QueryRow(ctx, getMessage, arg.ID, arg.AppID)
 	var i Message
 	err := row.Scan(
 		&i.ID,
@@ -192,16 +214,25 @@ func (q *Queries) GetMessage(ctx context.Context, id string) (Message, error) {
 }
 
 const getMessageInstance = `-- name: GetMessageInstance :one
-SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE id = $1 AND message_id = $2
+
+SELECT message_instances.id, message_instances.message_id, message_instances.hidden, message_instances.ephemeral, message_instances.discord_guild_id, message_instances.discord_channel_id, message_instances.discord_message_id, message_instances.flow_sources, message_instances.created_at, message_instances.updated_at FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.id = $1
+  AND message_instances.message_id = $2
+  AND messages.app_id = $3
 `
 
 type GetMessageInstanceParams struct {
 	ID        int64
 	MessageID string
+	AppID     string
 }
 
+// message_instances has no app_id of its own, so the queries below join through
+// messages to scope by app. The engine reaches these from Discord interactions,
+// where the message and instance IDs are supplied by whoever clicked.
 func (q *Queries) GetMessageInstance(ctx context.Context, arg GetMessageInstanceParams) (MessageInstance, error) {
-	row := q.db.QueryRow(ctx, getMessageInstance, arg.ID, arg.MessageID)
+	row := q.db.QueryRow(ctx, getMessageInstance, arg.ID, arg.MessageID, arg.AppID)
 	var i MessageInstance
 	err := row.Scan(
 		&i.ID,
@@ -219,11 +250,18 @@ func (q *Queries) GetMessageInstance(ctx context.Context, arg GetMessageInstance
 }
 
 const getMessageInstanceByDiscordMessageId = `-- name: GetMessageInstanceByDiscordMessageId :one
-SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE discord_message_id = $1
+SELECT message_instances.id, message_instances.message_id, message_instances.hidden, message_instances.ephemeral, message_instances.discord_guild_id, message_instances.discord_channel_id, message_instances.discord_message_id, message_instances.flow_sources, message_instances.created_at, message_instances.updated_at FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.discord_message_id = $1 AND messages.app_id = $2
 `
 
-func (q *Queries) GetMessageInstanceByDiscordMessageId(ctx context.Context, discordMessageID string) (MessageInstance, error) {
-	row := q.db.QueryRow(ctx, getMessageInstanceByDiscordMessageId, discordMessageID)
+type GetMessageInstanceByDiscordMessageIdParams struct {
+	DiscordMessageID string
+	AppID            string
+}
+
+func (q *Queries) GetMessageInstanceByDiscordMessageId(ctx context.Context, arg GetMessageInstanceByDiscordMessageIdParams) (MessageInstance, error) {
+	row := q.db.QueryRow(ctx, getMessageInstanceByDiscordMessageId, arg.DiscordMessageID, arg.AppID)
 	var i MessageInstance
 	err := row.Scan(
 		&i.ID,
@@ -241,11 +279,19 @@ func (q *Queries) GetMessageInstanceByDiscordMessageId(ctx context.Context, disc
 }
 
 const getMessageInstancesByMessage = `-- name: GetMessageInstancesByMessage :many
-SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE message_id = $1 AND NOT hidden ORDER BY created_at DESC
+SELECT message_instances.id, message_instances.message_id, message_instances.hidden, message_instances.ephemeral, message_instances.discord_guild_id, message_instances.discord_channel_id, message_instances.discord_message_id, message_instances.flow_sources, message_instances.created_at, message_instances.updated_at FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.message_id = $1 AND messages.app_id = $2 AND NOT message_instances.hidden
+ORDER BY message_instances.created_at DESC
 `
 
-func (q *Queries) GetMessageInstancesByMessage(ctx context.Context, messageID string) ([]MessageInstance, error) {
-	rows, err := q.db.Query(ctx, getMessageInstancesByMessage, messageID)
+type GetMessageInstancesByMessageParams struct {
+	MessageID string
+	AppID     string
+}
+
+func (q *Queries) GetMessageInstancesByMessage(ctx context.Context, arg GetMessageInstancesByMessageParams) ([]MessageInstance, error) {
+	rows, err := q.db.Query(ctx, getMessageInstancesByMessage, arg.MessageID, arg.AppID)
 	if err != nil {
 		return nil, err
 	}
@@ -276,11 +322,19 @@ func (q *Queries) GetMessageInstancesByMessage(ctx context.Context, messageID st
 }
 
 const getMessageInstancesByMessageWithHidden = `-- name: GetMessageInstancesByMessageWithHidden :many
-SELECT id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC
+SELECT message_instances.id, message_instances.message_id, message_instances.hidden, message_instances.ephemeral, message_instances.discord_guild_id, message_instances.discord_channel_id, message_instances.discord_message_id, message_instances.flow_sources, message_instances.created_at, message_instances.updated_at FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.message_id = $1 AND messages.app_id = $2
+ORDER BY message_instances.created_at DESC
 `
 
-func (q *Queries) GetMessageInstancesByMessageWithHidden(ctx context.Context, messageID string) ([]MessageInstance, error) {
-	rows, err := q.db.Query(ctx, getMessageInstancesByMessageWithHidden, messageID)
+type GetMessageInstancesByMessageWithHiddenParams struct {
+	MessageID string
+	AppID     string
+}
+
+func (q *Queries) GetMessageInstancesByMessageWithHidden(ctx context.Context, arg GetMessageInstancesByMessageWithHiddenParams) ([]MessageInstance, error) {
+	rows, err := q.db.Query(ctx, getMessageInstancesByMessageWithHidden, arg.MessageID, arg.AppID)
 	if err != nil {
 		return nil, err
 	}
@@ -391,14 +445,20 @@ func (q *Queries) UpdateMessage(ctx context.Context, arg UpdateMessageParams) (M
 
 const updateMessageInstance = `-- name: UpdateMessageInstance :one
 UPDATE message_instances SET
-    flow_sources = $3,
-    updated_at = $4
-WHERE id = $1 AND message_id = $2 RETURNING id, message_id, hidden, ephemeral, discord_guild_id, discord_channel_id, discord_message_id, flow_sources, created_at, updated_at
+    flow_sources = $4,
+    updated_at = $5
+FROM messages
+WHERE messages.id = message_instances.message_id
+  AND message_instances.id = $1
+  AND message_instances.message_id = $2
+  AND messages.app_id = $3
+RETURNING message_instances.id, message_instances.message_id, message_instances.hidden, message_instances.ephemeral, message_instances.discord_guild_id, message_instances.discord_channel_id, message_instances.discord_message_id, message_instances.flow_sources, message_instances.created_at, message_instances.updated_at
 `
 
 type UpdateMessageInstanceParams struct {
 	ID          int64
 	MessageID   string
+	AppID       string
 	FlowSources []byte
 	UpdatedAt   pgtype.Timestamp
 }
@@ -407,6 +467,7 @@ func (q *Queries) UpdateMessageInstance(ctx context.Context, arg UpdateMessageIn
 	row := q.db.QueryRow(ctx, updateMessageInstance,
 		arg.ID,
 		arg.MessageID,
+		arg.AppID,
 		arg.FlowSources,
 		arg.UpdatedAt,
 	)

--- a/kite-service/internal/db/postgres/pgmodel/resume_points.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/resume_points.sql.go
@@ -81,11 +81,19 @@ func (q *Queries) DeleteResumePoint(ctx context.Context, id string) error {
 }
 
 const resumePoint = `-- name: ResumePoint :one
-SELECT id, type, app_id, command_id, event_listener_id, message_id, message_instance_id, flow_source_id, flow_node_id, flow_state, created_at, expires_at FROM resume_points WHERE id = $1
+SELECT id, type, app_id, command_id, event_listener_id, message_id, message_instance_id, flow_source_id, flow_node_id, flow_state, created_at, expires_at FROM resume_points WHERE id = $1 AND app_id = $2
 `
 
-func (q *Queries) ResumePoint(ctx context.Context, id string) (ResumePoint, error) {
-	row := q.db.QueryRow(ctx, resumePoint, id)
+type ResumePointParams struct {
+	ID    string
+	AppID string
+}
+
+// The ID arrives in an interaction's custom_id, chosen by whoever built the
+// message, so it is not proof of ownership: scope by app or an app can resume
+// another app's flow, including its stored FlowState.
+func (q *Queries) ResumePoint(ctx context.Context, arg ResumePointParams) (ResumePoint, error) {
+	row := q.db.QueryRow(ctx, resumePoint, arg.ID, arg.AppID)
 	var i ResumePoint
 	err := row.Scan(
 		&i.ID,

--- a/kite-service/internal/db/postgres/pgmodel/variables.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/variables.sql.go
@@ -70,11 +70,20 @@ func (q *Queries) CreateVariable(ctx context.Context, arg CreateVariableParams) 
 }
 
 const deleteAllVariableValues = `-- name: DeleteAllVariableValues :exec
-DELETE FROM variable_values WHERE variable_id = $1
+DELETE FROM variable_values
+USING variables
+WHERE variables.id = variable_values.variable_id
+  AND variable_values.variable_id = $1
+  AND variables.app_id = $2
 `
 
-func (q *Queries) DeleteAllVariableValues(ctx context.Context, variableID string) error {
-	_, err := q.db.Exec(ctx, deleteAllVariableValues, variableID)
+type DeleteAllVariableValuesParams struct {
+	VariableID string
+	AppID      string
+}
+
+func (q *Queries) DeleteAllVariableValues(ctx context.Context, arg DeleteAllVariableValuesParams) error {
+	_, err := q.db.Exec(ctx, deleteAllVariableValues, arg.VariableID, arg.AppID)
 	return err
 }
 
@@ -88,19 +97,25 @@ func (q *Queries) DeleteVariable(ctx context.Context, id string) error {
 }
 
 const deleteVariableValue = `-- name: DeleteVariableValue :exec
-DELETE FROM variable_values WHERE variable_id = $1 AND scope IS NOT DISTINCT FROM $2
+DELETE FROM variable_values
+USING variables
+WHERE variables.id = variable_values.variable_id
+  AND variable_values.variable_id = $1
+  AND variable_values.scope IS NOT DISTINCT FROM $2
+  AND variables.app_id = $3
 `
 
 type DeleteVariableValueParams struct {
 	VariableID string
 	Scope      pgtype.Text
+	AppID      string
 }
 
 // IS NOT DISTINCT FROM so that unscoped values (scope IS NULL) are matched,
 // same as the get queries above. Plain `= NULL` never matches and made
 // deleting an unscoped variable value a silent no-op.
 func (q *Queries) DeleteVariableValue(ctx context.Context, arg DeleteVariableValueParams) error {
-	_, err := q.db.Exec(ctx, deleteVariableValue, arg.VariableID, arg.Scope)
+	_, err := q.db.Exec(ctx, deleteVariableValue, arg.VariableID, arg.Scope, arg.AppID)
 	return err
 }
 
@@ -166,16 +181,26 @@ func (q *Queries) GetVariableByName(ctx context.Context, arg GetVariableByNamePa
 }
 
 const getVariableValue = `-- name: GetVariableValue :one
-SELECT id, variable_id, scope, value, created_at, updated_at FROM variable_values WHERE variable_id = $1 AND scope IS NOT DISTINCT FROM $2
+
+SELECT variable_values.id, variable_values.variable_id, variable_values.scope, variable_values.value, variable_values.created_at, variable_values.updated_at FROM variable_values
+JOIN variables ON variables.id = variable_values.variable_id
+WHERE variable_values.variable_id = $1
+  AND variable_values.scope IS NOT DISTINCT FROM $2
+  AND variables.app_id = $3
 `
 
 type GetVariableValueParams struct {
 	VariableID string
 	Scope      pgtype.Text
+	AppID      string
 }
 
+// variable_values has no app_id of its own, so every query below joins through
+// variables to scope by app. Without that a variable_id alone is enough to read
+// or write the row, and variable_ids reach the engine straight out of
+// user-authored flow JSON -- which is portable between apps via flow import.
 func (q *Queries) GetVariableValue(ctx context.Context, arg GetVariableValueParams) (VariableValue, error) {
-	row := q.db.QueryRow(ctx, getVariableValue, arg.VariableID, arg.Scope)
+	row := q.db.QueryRow(ctx, getVariableValue, arg.VariableID, arg.Scope, arg.AppID)
 	var i VariableValue
 	err := row.Scan(
 		&i.ID,
@@ -189,16 +214,24 @@ func (q *Queries) GetVariableValue(ctx context.Context, arg GetVariableValuePara
 }
 
 const getVariableValueForUpdate = `-- name: GetVariableValueForUpdate :one
-SELECT id, variable_id, scope, value, created_at, updated_at FROM variable_values WHERE variable_id = $1 AND scope IS NOT DISTINCT FROM $2 FOR UPDATE
+SELECT variable_values.id, variable_values.variable_id, variable_values.scope, variable_values.value, variable_values.created_at, variable_values.updated_at FROM variable_values
+JOIN variables ON variables.id = variable_values.variable_id
+WHERE variable_values.variable_id = $1
+  AND variable_values.scope IS NOT DISTINCT FROM $2
+  AND variables.app_id = $3
+FOR UPDATE OF variable_values
 `
 
 type GetVariableValueForUpdateParams struct {
 	VariableID string
 	Scope      pgtype.Text
+	AppID      string
 }
 
+// FOR UPDATE OF, not a bare FOR UPDATE: the latter would also lock the joined
+// variables row for the duration of the transaction.
 func (q *Queries) GetVariableValueForUpdate(ctx context.Context, arg GetVariableValueForUpdateParams) (VariableValue, error) {
-	row := q.db.QueryRow(ctx, getVariableValueForUpdate, arg.VariableID, arg.Scope)
+	row := q.db.QueryRow(ctx, getVariableValueForUpdate, arg.VariableID, arg.Scope, arg.AppID)
 	var i VariableValue
 	err := row.Scan(
 		&i.ID,
@@ -212,11 +245,18 @@ func (q *Queries) GetVariableValueForUpdate(ctx context.Context, arg GetVariable
 }
 
 const getVariableValues = `-- name: GetVariableValues :many
-SELECT id, variable_id, scope, value, created_at, updated_at FROM variable_values WHERE variable_id = $1
+SELECT variable_values.id, variable_values.variable_id, variable_values.scope, variable_values.value, variable_values.created_at, variable_values.updated_at FROM variable_values
+JOIN variables ON variables.id = variable_values.variable_id
+WHERE variable_values.variable_id = $1 AND variables.app_id = $2
 `
 
-func (q *Queries) GetVariableValues(ctx context.Context, variableID string) ([]VariableValue, error) {
-	rows, err := q.db.Query(ctx, getVariableValues, variableID)
+type GetVariableValuesParams struct {
+	VariableID string
+	AppID      string
+}
+
+func (q *Queries) GetVariableValues(ctx context.Context, arg GetVariableValuesParams) ([]VariableValue, error) {
+	rows, err := q.db.Query(ctx, getVariableValues, arg.VariableID, arg.AppID)
 	if err != nil {
 		return nil, err
 	}
@@ -291,29 +331,41 @@ INSERT INTO variable_values (
     value,
     created_at,
     updated_at
-) VALUES (
-    $1, $2, $3, $4, $5
-) ON CONFLICT (variable_id, scope) DO UPDATE SET
+)
+SELECT
+    variables.id,
+    $1::text,
+    $2::jsonb,
+    $3::timestamp,
+    $4::timestamp
+FROM variables
+WHERE variables.id = $5 AND variables.app_id = $6
+ON CONFLICT (variable_id, scope) DO UPDATE SET
     value = EXCLUDED.value,
     updated_at = EXCLUDED.updated_at
 RETURNING id, variable_id, scope, value, created_at, updated_at
 `
 
 type SetVariableValueParams struct {
-	VariableID string
 	Scope      pgtype.Text
 	Value      []byte
 	CreatedAt  pgtype.Timestamp
 	UpdatedAt  pgtype.Timestamp
+	VariableID string
+	AppID      string
 }
 
+// INSERT ... SELECT rather than VALUES so the app check is part of the write:
+// if the variable does not belong to the app the select is empty, nothing is
+// inserted, and :one surfaces it as ErrNoRows.
 func (q *Queries) SetVariableValue(ctx context.Context, arg SetVariableValueParams) (VariableValue, error) {
 	row := q.db.QueryRow(ctx, setVariableValue,
-		arg.VariableID,
 		arg.Scope,
 		arg.Value,
 		arg.CreatedAt,
 		arg.UpdatedAt,
+		arg.VariableID,
+		arg.AppID,
 	)
 	var i VariableValue
 	err := row.Scan(

--- a/kite-service/internal/db/postgres/queries/messages.sql
+++ b/kite-service/internal/db/postgres/queries/messages.sql
@@ -37,7 +37,14 @@ WHERE id = $1 RETURNING *;
 -- name: DeleteMessage :exec
 DELETE FROM messages WHERE id = $1;
 
+-- message_instances has no app_id of its own, so the queries below reach the app
+-- through messages. The engine reaches these from Discord interactions, where
+-- the message and instance IDs are supplied by whoever clicked.
+
 -- name: CreateMessageInstance :one
+-- INSERT ... SELECT rather than VALUES so the app check is part of the write:
+-- if the message does not belong to the app the select is empty, nothing is
+-- inserted, and :one surfaces it as ErrNoRows.
 INSERT INTO message_instances (
     message_id,
     discord_guild_id,
@@ -48,13 +55,10 @@ INSERT INTO message_instances (
     flow_sources,
     created_at,
     updated_at
-) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9
-) RETURNING *;
-
--- message_instances has no app_id of its own, so the queries below join through
--- messages to scope by app. The engine reaches these from Discord interactions,
--- where the message and instance IDs are supplied by whoever clicked.
+)
+SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9
+FROM messages WHERE messages.id = $1 AND messages.app_id = $10
+RETURNING *;
 
 -- name: GetMessageInstance :one
 SELECT message_instances.* FROM message_instances

--- a/kite-service/internal/db/postgres/queries/messages.sql
+++ b/kite-service/internal/db/postgres/queries/messages.sql
@@ -1,5 +1,7 @@
 -- name: GetMessage :one
-SELECT * FROM messages WHERE id = $1;
+-- Scoped by app: the message ID reaches the engine from flow node config that
+-- the tenant authored, so an ID on its own is not proof of ownership.
+SELECT * FROM messages WHERE id = $1 AND app_id = $2;
 
 -- name: GetMessagesByApp :many
 SELECT * FROM messages WHERE app_id = $1 ORDER BY created_at DESC;
@@ -50,26 +52,56 @@ INSERT INTO message_instances (
     $1, $2, $3, $4, $5, $6, $7, $8, $9
 ) RETURNING *;
 
+-- message_instances has no app_id of its own, so the queries below join through
+-- messages to scope by app. The engine reaches these from Discord interactions,
+-- where the message and instance IDs are supplied by whoever clicked.
+
 -- name: GetMessageInstance :one
-SELECT * FROM message_instances WHERE id = $1 AND message_id = $2;
+SELECT message_instances.* FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.id = $1
+  AND message_instances.message_id = $2
+  AND messages.app_id = $3;
 
 -- name: GetMessageInstancesByMessage :many
-SELECT * FROM message_instances WHERE message_id = $1 AND NOT hidden ORDER BY created_at DESC;
+SELECT message_instances.* FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.message_id = $1 AND messages.app_id = $2 AND NOT message_instances.hidden
+ORDER BY message_instances.created_at DESC;
 
 -- name: GetMessageInstancesByMessageWithHidden :many
-SELECT * FROM message_instances WHERE message_id = $1 ORDER BY created_at DESC;
+SELECT message_instances.* FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.message_id = $1 AND messages.app_id = $2
+ORDER BY message_instances.created_at DESC;
 
 -- name: GetMessageInstanceByDiscordMessageId :one
-SELECT * FROM message_instances WHERE discord_message_id = $1;
+SELECT message_instances.* FROM message_instances
+JOIN messages ON messages.id = message_instances.message_id
+WHERE message_instances.discord_message_id = $1 AND messages.app_id = $2;
 
 -- name: UpdateMessageInstance :one
 UPDATE message_instances SET
-    flow_sources = $3,
-    updated_at = $4
-WHERE id = $1 AND message_id = $2 RETURNING *;
+    flow_sources = $4,
+    updated_at = $5
+FROM messages
+WHERE messages.id = message_instances.message_id
+  AND message_instances.id = $1
+  AND message_instances.message_id = $2
+  AND messages.app_id = $3
+RETURNING message_instances.*;
 
 -- name: DeleteMessageInstance :exec
-DELETE FROM message_instances WHERE id = $1 AND message_id = $2;
+DELETE FROM message_instances
+USING messages
+WHERE messages.id = message_instances.message_id
+  AND message_instances.id = $1
+  AND message_instances.message_id = $2
+  AND messages.app_id = $3;
 
 -- name: DeleteMessageInstanceByDiscordMessageId :exec
-DELETE FROM message_instances WHERE discord_message_id = $1;
+DELETE FROM message_instances
+USING messages
+WHERE messages.id = message_instances.message_id
+  AND message_instances.discord_message_id = $1
+  AND messages.app_id = $2;

--- a/kite-service/internal/db/postgres/queries/resume_points.sql
+++ b/kite-service/internal/db/postgres/queries/resume_points.sql
@@ -22,4 +22,7 @@ DELETE FROM resume_points WHERE id = $1;
 DELETE FROM resume_points WHERE expires_at < $1;
 
 -- name: ResumePoint :one
-SELECT * FROM resume_points WHERE id = $1;
+-- The ID arrives in an interaction's custom_id, chosen by whoever built the
+-- message, so it is not proof of ownership: scope by app or an app can resume
+-- another app's flow, including its stored FlowState.
+SELECT * FROM resume_points WHERE id = $1 AND app_id = $2;

--- a/kite-service/internal/db/postgres/queries/variables.sql
+++ b/kite-service/internal/db/postgres/queries/variables.sql
@@ -43,25 +43,53 @@ WHERE id = $1 RETURNING *;
 -- name: DeleteVariable :exec
 DELETE FROM variables WHERE id = $1;
 
+-- variable_values has no app_id of its own, so every query below joins through
+-- variables to scope by app. Without that a variable_id alone is enough to read
+-- or write the row, and variable_ids reach the engine straight out of
+-- user-authored flow JSON -- which is portable between apps via flow import.
+
 -- name: GetVariableValue :one
-SELECT * FROM variable_values WHERE variable_id = $1 AND scope IS NOT DISTINCT FROM $2;
+SELECT variable_values.* FROM variable_values
+JOIN variables ON variables.id = variable_values.variable_id
+WHERE variable_values.variable_id = $1
+  AND variable_values.scope IS NOT DISTINCT FROM $2
+  AND variables.app_id = $3;
 
 -- name: GetVariableValueForUpdate :one
-SELECT * FROM variable_values WHERE variable_id = $1 AND scope IS NOT DISTINCT FROM $2 FOR UPDATE;
+-- FOR UPDATE OF, not a bare FOR UPDATE: the latter would also lock the joined
+-- variables row for the duration of the transaction.
+SELECT variable_values.* FROM variable_values
+JOIN variables ON variables.id = variable_values.variable_id
+WHERE variable_values.variable_id = $1
+  AND variable_values.scope IS NOT DISTINCT FROM $2
+  AND variables.app_id = $3
+FOR UPDATE OF variable_values;
 
 -- name: GetVariableValues :many
-SELECT * FROM variable_values WHERE variable_id = $1;
+SELECT variable_values.* FROM variable_values
+JOIN variables ON variables.id = variable_values.variable_id
+WHERE variable_values.variable_id = $1 AND variables.app_id = $2;
 
 -- name: SetVariableValue :one
+-- INSERT ... SELECT rather than VALUES so the app check is part of the write:
+-- if the variable does not belong to the app the select is empty, nothing is
+-- inserted, and :one surfaces it as ErrNoRows.
 INSERT INTO variable_values (
     variable_id,
     scope,
     value,
     created_at,
     updated_at
-) VALUES (
-    $1, $2, $3, $4, $5
-) ON CONFLICT (variable_id, scope) DO UPDATE SET
+)
+SELECT
+    variables.id,
+    sqlc.narg(scope)::text,
+    @value::jsonb,
+    @created_at::timestamp,
+    @updated_at::timestamp
+FROM variables
+WHERE variables.id = @variable_id AND variables.app_id = @app_id
+ON CONFLICT (variable_id, scope) DO UPDATE SET
     value = EXCLUDED.value,
     updated_at = EXCLUDED.updated_at
 RETURNING *;
@@ -70,7 +98,16 @@ RETURNING *;
 -- IS NOT DISTINCT FROM so that unscoped values (scope IS NULL) are matched,
 -- same as the get queries above. Plain `= NULL` never matches and made
 -- deleting an unscoped variable value a silent no-op.
-DELETE FROM variable_values WHERE variable_id = $1 AND scope IS NOT DISTINCT FROM $2;
+DELETE FROM variable_values
+USING variables
+WHERE variables.id = variable_values.variable_id
+  AND variable_values.variable_id = $1
+  AND variable_values.scope IS NOT DISTINCT FROM $2
+  AND variables.app_id = $3;
 
 -- name: DeleteAllVariableValues :exec
-DELETE FROM variable_values WHERE variable_id = $1;
+DELETE FROM variable_values
+USING variables
+WHERE variables.id = variable_values.variable_id
+  AND variable_values.variable_id = $1
+  AND variables.app_id = $2;

--- a/kite-service/internal/db/postgres/queries_scoping_test.go
+++ b/kite-service/internal/db/postgres/queries_scoping_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// variable_values and message_instances carry no app_id column, so they are
+// only tenant-safe when the query reaches the app through variables/messages.
+// The IDs these queries take come from tenant-authored flow config and from
+// Discord interactions, so dropping the join silently reopens cross-tenant
+// reads and writes -- and nothing else in the test suite touches SQL, since
+// there is no database here.
+//
+// This asserts on the query files rather than the generated code: they are the
+// source of truth, and a regenerate would carry a mistake straight through.
+
+func readQueryFile(t *testing.T, name string) string {
+	t.Helper()
+
+	content, err := os.ReadFile("queries/" + name)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", name, err)
+	}
+	return string(content)
+}
+
+// splitQueries breaks a .sql file into one chunk per `-- name:` block, keyed by
+// the query name.
+func splitQueries(t *testing.T, content string) map[string]string {
+	t.Helper()
+
+	queries := make(map[string]string)
+	for _, block := range strings.Split(content, "-- name: ")[1:] {
+		name, _, ok := strings.Cut(block, " ")
+		if !ok {
+			t.Fatalf("malformed query block: %.60s", block)
+		}
+		queries[name] = block
+	}
+	return queries
+}
+
+func assertScopedByApp(t *testing.T, file string, names ...string) {
+	t.Helper()
+
+	queries := splitQueries(t, readQueryFile(t, file))
+
+	for _, name := range names {
+		body, ok := queries[name]
+		if !ok {
+			t.Errorf("%s: query %q not found -- renamed without updating this test?", file, name)
+			continue
+		}
+		if !strings.Contains(body, "app_id") {
+			t.Errorf("%s: query %q is not scoped by app_id:\n%s", file, name, body)
+		}
+	}
+}
+
+func TestVariableValueQueriesAreScopedByApp(t *testing.T) {
+	assertScopedByApp(t, "variables.sql",
+		"GetVariableValue",
+		"GetVariableValueForUpdate",
+		"GetVariableValues",
+		"SetVariableValue",
+		"DeleteVariableValue",
+		"DeleteAllVariableValues",
+	)
+}
+
+func TestMessageQueriesAreScopedByApp(t *testing.T) {
+	assertScopedByApp(t, "messages.sql",
+		"GetMessage",
+		"GetMessageInstance",
+		"GetMessageInstancesByMessage",
+		"GetMessageInstancesByMessageWithHidden",
+		"GetMessageInstanceByDiscordMessageId",
+		"UpdateMessageInstance",
+		"DeleteMessageInstance",
+		"DeleteMessageInstanceByDiscordMessageId",
+	)
+}

--- a/kite-service/internal/db/postgres/queries_scoping_test.go
+++ b/kite-service/internal/db/postgres/queries_scoping_test.go
@@ -13,72 +13,78 @@ import (
 // reads and writes -- and nothing else in the test suite touches SQL, since
 // there is no database here.
 //
-// This asserts on the query files rather than the generated code: they are the
-// source of truth, and a regenerate would carry a mistake straight through.
+// This is default-deny over the query files rather than a list of query names:
+// a query added later is covered the day it is written, without anyone
+// remembering to come back here. The query files are also the source of truth,
+// and a regenerate would carry a mistake straight through to the generated
+// code.
 
-func readQueryFile(t *testing.T, name string) string {
-	t.Helper()
+// scopedTables must never be reached without also naming app_id.
+var scopedTables = []string{"variable_values", "message_instances"}
 
-	content, err := os.ReadFile("queries/" + name)
-	if err != nil {
-		t.Fatalf("failed to read %s: %v", name, err)
-	}
-	return string(content)
+// exemptQueries opt out of the rule above. Every entry needs a reason, and the
+// reason has to be that the query cannot leak across tenants -- not that
+// scoping it is inconvenient.
+var exemptQueries = map[string]string{
+	// Keyed on the parent, not the child: the join only counts the variable's
+	// own values, so no child row is reachable by its own id. Whether the
+	// parent lookup itself is scoped is VariableAccess's problem, not this
+	// query's.
+	"GetVariable": "aggregates the parent's own children, never keyed by child id",
 }
 
 // splitQueries breaks a .sql file into one chunk per `-- name:` block, keyed by
-// the query name.
+// the query name, with `--` comments stripped so a rationale mentioning app_id
+// cannot pass for an actual predicate.
 func splitQueries(t *testing.T, content string) map[string]string {
 	t.Helper()
 
 	queries := make(map[string]string)
 	for _, block := range strings.Split(content, "-- name: ")[1:] {
-		name, _, ok := strings.Cut(block, " ")
+		name, body, ok := strings.Cut(block, "\n")
 		if !ok {
 			t.Fatalf("malformed query block: %.60s", block)
 		}
-		queries[name] = block
+		name, _, _ = strings.Cut(name, " ")
+
+		var stripped strings.Builder
+		for _, line := range strings.Split(body, "\n") {
+			if code, _, found := strings.Cut(line, "--"); found {
+				stripped.WriteString(code)
+			} else {
+				stripped.WriteString(line)
+			}
+			stripped.WriteString("\n")
+		}
+		queries[name] = stripped.String()
 	}
 	return queries
 }
 
-func assertScopedByApp(t *testing.T, file string, names ...string) {
+func assertScopedByApp(t *testing.T, file string) {
 	t.Helper()
 
-	queries := splitQueries(t, readQueryFile(t, file))
+	content, err := os.ReadFile("queries/" + file)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", file, err)
+	}
 
-	for _, name := range names {
-		body, ok := queries[name]
-		if !ok {
-			t.Errorf("%s: query %q not found -- renamed without updating this test?", file, name)
+	for name, body := range splitQueries(t, string(content)) {
+		if _, exempt := exemptQueries[name]; exempt {
 			continue
 		}
-		if !strings.Contains(body, "app_id") {
-			t.Errorf("%s: query %q is not scoped by app_id:\n%s", file, name, body)
+		for _, table := range scopedTables {
+			if strings.Contains(body, table) && !strings.Contains(body, "app_id") {
+				t.Errorf("%s: query %q touches %s but is not scoped by app_id:\n%s", file, name, table, body)
+			}
 		}
 	}
 }
 
-func TestVariableValueQueriesAreScopedByApp(t *testing.T) {
-	assertScopedByApp(t, "variables.sql",
-		"GetVariableValue",
-		"GetVariableValueForUpdate",
-		"GetVariableValues",
-		"SetVariableValue",
-		"DeleteVariableValue",
-		"DeleteAllVariableValues",
-	)
+func TestVariableQueriesAreScopedByApp(t *testing.T) {
+	assertScopedByApp(t, "variables.sql")
 }
 
 func TestMessageQueriesAreScopedByApp(t *testing.T) {
-	assertScopedByApp(t, "messages.sql",
-		"GetMessage",
-		"GetMessageInstance",
-		"GetMessageInstancesByMessage",
-		"GetMessageInstancesByMessageWithHidden",
-		"GetMessageInstanceByDiscordMessageId",
-		"UpdateMessageInstance",
-		"DeleteMessageInstance",
-		"DeleteMessageInstanceByDiscordMessageId",
-	)
+	assertScopedByApp(t, "messages.sql")
 }

--- a/kite-service/internal/db/postgres/store_message.go
+++ b/kite-service/internal/db/postgres/store_message.go
@@ -40,8 +40,11 @@ func (c *Client) CountMessagesByApp(ctx context.Context, appID string) (int, err
 	return int(res), nil
 }
 
-func (c *Client) Message(ctx context.Context, id string) (*model.Message, error) {
-	row, err := c.Q.GetMessage(ctx, id)
+func (c *Client) Message(ctx context.Context, appID string, id string) (*model.Message, error) {
+	row, err := c.Q.GetMessage(ctx, pgmodel.GetMessageParams{
+		ID:    id,
+		AppID: appID,
+	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, store.ErrNotFound
@@ -157,10 +160,11 @@ func rowToMessage(row pgmodel.Message) (*model.Message, error) {
 	}, nil
 }
 
-func (c *Client) MessageInstance(ctx context.Context, messageID string, instanceID uint64) (*model.MessageInstance, error) {
+func (c *Client) MessageInstance(ctx context.Context, appID string, messageID string, instanceID uint64) (*model.MessageInstance, error) {
 	row, err := c.Q.GetMessageInstance(ctx, pgmodel.GetMessageInstanceParams{
 		MessageID: messageID,
 		ID:        int64(instanceID),
+		AppID:     appID,
 	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -172,14 +176,20 @@ func (c *Client) MessageInstance(ctx context.Context, messageID string, instance
 	return rowToMessageInstance(row)
 }
 
-func (c *Client) MessageInstancesByMessage(ctx context.Context, messageID string, includeHidden bool) ([]*model.MessageInstance, error) {
+func (c *Client) MessageInstancesByMessage(ctx context.Context, appID string, messageID string, includeHidden bool) ([]*model.MessageInstance, error) {
 	var rows []pgmodel.MessageInstance
 	var err error
 
 	if includeHidden {
-		rows, err = c.Q.GetMessageInstancesByMessageWithHidden(ctx, messageID)
+		rows, err = c.Q.GetMessageInstancesByMessageWithHidden(ctx, pgmodel.GetMessageInstancesByMessageWithHiddenParams{
+			MessageID: messageID,
+			AppID:     appID,
+		})
 	} else {
-		rows, err = c.Q.GetMessageInstancesByMessage(ctx, messageID)
+		rows, err = c.Q.GetMessageInstancesByMessage(ctx, pgmodel.GetMessageInstancesByMessageParams{
+			MessageID: messageID,
+			AppID:     appID,
+		})
 	}
 	if err != nil {
 		return nil, err
@@ -197,8 +207,11 @@ func (c *Client) MessageInstancesByMessage(ctx context.Context, messageID string
 	return instances, nil
 }
 
-func (c *Client) MessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) (*model.MessageInstance, error) {
-	row, err := c.Q.GetMessageInstanceByDiscordMessageId(ctx, discordMessageID)
+func (c *Client) MessageInstanceByDiscordMessageID(ctx context.Context, appID string, discordMessageID string) (*model.MessageInstance, error) {
+	row, err := c.Q.GetMessageInstanceByDiscordMessageId(ctx, pgmodel.GetMessageInstanceByDiscordMessageIdParams{
+		DiscordMessageID: discordMessageID,
+		AppID:            appID,
+	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, store.ErrNotFound
@@ -233,7 +246,7 @@ func (c *Client) CreateMessageInstance(ctx context.Context, instance *model.Mess
 	return rowToMessageInstance(res)
 }
 
-func (c *Client) UpdateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error) {
+func (c *Client) UpdateMessageInstance(ctx context.Context, appID string, instance *model.MessageInstance) (*model.MessageInstance, error) {
 	flowSources, err := json.Marshal(instance.FlowSources)
 	if err != nil {
 		return nil, err
@@ -242,6 +255,7 @@ func (c *Client) UpdateMessageInstance(ctx context.Context, instance *model.Mess
 	res, err := c.Q.UpdateMessageInstance(ctx, pgmodel.UpdateMessageInstanceParams{
 		ID:          int64(instance.ID),
 		MessageID:   instance.MessageID,
+		AppID:       appID,
 		FlowSources: flowSources,
 		UpdatedAt:   pgtype.Timestamp{Time: instance.UpdatedAt.UTC(), Valid: true},
 	})
@@ -255,10 +269,11 @@ func (c *Client) UpdateMessageInstance(ctx context.Context, instance *model.Mess
 	return rowToMessageInstance(res)
 }
 
-func (c *Client) DeleteMessageInstance(ctx context.Context, messageID string, instanceID uint64) error {
+func (c *Client) DeleteMessageInstance(ctx context.Context, appID string, messageID string, instanceID uint64) error {
 	err := c.Q.DeleteMessageInstance(ctx, pgmodel.DeleteMessageInstanceParams{
 		MessageID: messageID,
 		ID:        int64(instanceID),
+		AppID:     appID,
 	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -270,8 +285,11 @@ func (c *Client) DeleteMessageInstance(ctx context.Context, messageID string, in
 	return nil
 }
 
-func (c *Client) DeleteMessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) error {
-	err := c.Q.DeleteMessageInstanceByDiscordMessageId(ctx, discordMessageID)
+func (c *Client) DeleteMessageInstanceByDiscordMessageID(ctx context.Context, appID string, discordMessageID string) error {
+	err := c.Q.DeleteMessageInstanceByDiscordMessageId(ctx, pgmodel.DeleteMessageInstanceByDiscordMessageIdParams{
+		DiscordMessageID: discordMessageID,
+		AppID:            appID,
+	})
 	if err != nil {
 		if err == pgx.ErrNoRows {
 			return store.ErrNotFound

--- a/kite-service/internal/db/postgres/store_message.go
+++ b/kite-service/internal/db/postgres/store_message.go
@@ -222,13 +222,14 @@ func (c *Client) MessageInstanceByDiscordMessageID(ctx context.Context, appID st
 	return rowToMessageInstance(row)
 }
 
-func (c *Client) CreateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error) {
+func (c *Client) CreateMessageInstance(ctx context.Context, appID string, instance *model.MessageInstance) (*model.MessageInstance, error) {
 	flowSources, err := json.Marshal(instance.FlowSources)
 	if err != nil {
 		return nil, err
 	}
 
 	res, err := c.Q.CreateMessageInstance(ctx, pgmodel.CreateMessageInstanceParams{
+		AppID:            appID,
 		MessageID:        instance.MessageID,
 		DiscordGuildID:   instance.DiscordGuildID,
 		DiscordChannelID: instance.DiscordChannelID,
@@ -240,6 +241,9 @@ func (c *Client) CreateMessageInstance(ctx context.Context, instance *model.Mess
 		UpdatedAt:        pgtype.Timestamp{Time: instance.UpdatedAt.UTC(), Valid: true},
 	})
 	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, store.ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/kite-service/internal/db/postgres/store_resume_point.go
+++ b/kite-service/internal/db/postgres/store_resume_point.go
@@ -51,8 +51,11 @@ func (c *Client) DeleteExpiredResumePoints(ctx context.Context, now time.Time) e
 	return c.Q.DeleteExpiredResumePoints(ctx, pgtype.Timestamp{Time: now, Valid: true})
 }
 
-func (c *Client) ResumePoint(ctx context.Context, id string) (*model.ResumePoint, error) {
-	row, err := c.Q.ResumePoint(ctx, id)
+func (c *Client) ResumePoint(ctx context.Context, appID string, id string) (*model.ResumePoint, error) {
+	row, err := c.Q.ResumePoint(ctx, pgmodel.ResumePointParams{
+		ID:    id,
+		AppID: appID,
+	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, store.ErrNotFound

--- a/kite-service/internal/db/postgres/store_variable.go
+++ b/kite-service/internal/db/postgres/store_variable.go
@@ -141,8 +141,11 @@ func rowToVariable(row pgmodel.Variable) *model.Variable {
 	}
 }
 
-func (c *Client) VariableValues(ctx context.Context, variableID string) ([]*model.VariableValue, error) {
-	rows, err := c.Q.GetVariableValues(ctx, variableID)
+func (c *Client) VariableValues(ctx context.Context, appID string, variableID string) ([]*model.VariableValue, error) {
+	rows, err := c.Q.GetVariableValues(ctx, pgmodel.GetVariableValuesParams{
+		VariableID: variableID,
+		AppID:      appID,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -159,10 +162,11 @@ func (c *Client) VariableValues(ctx context.Context, variableID string) ([]*mode
 	return values, nil
 }
 
-func (c *Client) VariableValue(ctx context.Context, variableID string, scope null.String) (*model.VariableValue, error) {
+func (c *Client) VariableValue(ctx context.Context, appID string, variableID string, scope null.String) (*model.VariableValue, error) {
 	row, err := c.Q.GetVariableValue(ctx, pgmodel.GetVariableValueParams{
 		VariableID: variableID,
 		Scope:      pgtype.Text{String: scope.String, Valid: scope.Valid},
+		AppID:      appID,
 	})
 
 	if err != nil {
@@ -180,14 +184,14 @@ func (c *Client) VariableValue(ctx context.Context, variableID string, scope nul
 	return &v, nil
 }
 
-func (c *Client) SetVariableValue(ctx context.Context, value model.VariableValue) error {
-	_, err := c.setVariableValueWithTx(ctx, nil, value)
+func (c *Client) SetVariableValue(ctx context.Context, appID string, value model.VariableValue) error {
+	_, err := c.setVariableValueWithTx(ctx, nil, appID, value)
 	return err
 }
 
-func (c *Client) UpdateVariableValue(ctx context.Context, operation model.VariableValueOperation, value model.VariableValue) (*model.VariableValue, error) {
+func (c *Client) UpdateVariableValue(ctx context.Context, appID string, operation model.VariableValueOperation, value model.VariableValue) (*model.VariableValue, error) {
 	if operation == provider.VariableOperationOverwrite {
-		return c.setVariableValueWithTx(ctx, nil, value)
+		return c.setVariableValueWithTx(ctx, nil, appID, value)
 	}
 
 	tx, err := c.DB.Begin(ctx)
@@ -196,11 +200,11 @@ func (c *Client) UpdateVariableValue(ctx context.Context, operation model.Variab
 	}
 	defer tx.Rollback(ctx)
 
-	currentValue, err := c.variableValueWithTx(ctx, tx, value.VariableID, value.Scope)
+	currentValue, err := c.variableValueWithTx(ctx, tx, appID, value.VariableID, value.Scope)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			// Current trasaction is rolled back, we set the value outside of the transaction
-			return c.setVariableValueWithTx(ctx, nil, value)
+			return c.setVariableValueWithTx(ctx, nil, appID, value)
 		}
 		return nil, fmt.Errorf("failed to get current variable value: %w", err)
 	}
@@ -216,7 +220,7 @@ func (c *Client) UpdateVariableValue(ctx context.Context, operation model.Variab
 		value.Data = currentValue.Data.Sub(value.Data)
 	}
 
-	newValue, err := c.setVariableValueWithTx(ctx, tx, value)
+	newValue, err := c.setVariableValueWithTx(ctx, tx, appID, value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set variable value: %w", err)
 	}
@@ -229,10 +233,11 @@ func (c *Client) UpdateVariableValue(ctx context.Context, operation model.Variab
 	return newValue, nil
 }
 
-func (c *Client) DeleteVariableValue(ctx context.Context, variableID string, scope null.String) error {
+func (c *Client) DeleteVariableValue(ctx context.Context, appID string, variableID string, scope null.String) error {
 	err := c.Q.DeleteVariableValue(ctx, pgmodel.DeleteVariableValueParams{
 		VariableID: variableID,
 		Scope:      pgtype.Text{String: scope.String, Valid: scope.Valid},
+		AppID:      appID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -244,8 +249,11 @@ func (c *Client) DeleteVariableValue(ctx context.Context, variableID string, sco
 	return nil
 }
 
-func (c *Client) DeleteAllVariableValues(ctx context.Context, variableID string) error {
-	err := c.Q.DeleteAllVariableValues(ctx, variableID)
+func (c *Client) DeleteAllVariableValues(ctx context.Context, appID string, variableID string) error {
+	err := c.Q.DeleteAllVariableValues(ctx, pgmodel.DeleteAllVariableValuesParams{
+		VariableID: variableID,
+		AppID:      appID,
+	})
 	if err != nil {
 		return err
 	}
@@ -253,7 +261,7 @@ func (c *Client) DeleteAllVariableValues(ctx context.Context, variableID string)
 	return nil
 }
 
-func (c *Client) variableValueWithTx(ctx context.Context, tx pgx.Tx, variableID string, scope null.String) (*model.VariableValue, error) {
+func (c *Client) variableValueWithTx(ctx context.Context, tx pgx.Tx, appID string, variableID string, scope null.String) (*model.VariableValue, error) {
 	q := c.Q
 	if tx != nil {
 		q = c.Q.WithTx(tx)
@@ -262,6 +270,7 @@ func (c *Client) variableValueWithTx(ctx context.Context, tx pgx.Tx, variableID 
 	row, err := q.GetVariableValueForUpdate(ctx, pgmodel.GetVariableValueForUpdateParams{
 		VariableID: variableID,
 		Scope:      pgtype.Text{String: scope.String, Valid: scope.Valid},
+		AppID:      appID,
 	})
 
 	if err != nil {
@@ -279,7 +288,7 @@ func (c *Client) variableValueWithTx(ctx context.Context, tx pgx.Tx, variableID 
 	return &v, nil
 }
 
-func (c *Client) setVariableValueWithTx(ctx context.Context, tx pgx.Tx, value model.VariableValue) (*model.VariableValue, error) {
+func (c *Client) setVariableValueWithTx(ctx context.Context, tx pgx.Tx, appID string, value model.VariableValue) (*model.VariableValue, error) {
 	q := c.Q
 	if tx != nil {
 		q = c.Q.WithTx(tx)
@@ -292,12 +301,18 @@ func (c *Client) setVariableValueWithTx(ctx context.Context, tx pgx.Tx, value mo
 
 	row, err := q.SetVariableValue(ctx, pgmodel.SetVariableValueParams{
 		VariableID: value.VariableID,
+		AppID:      appID,
 		Scope:      pgtype.Text{String: value.Scope.String, Valid: value.Scope.Valid},
 		Value:      data,
 		CreatedAt:  pgtype.Timestamp{Time: value.CreatedAt, Valid: true},
 		UpdatedAt:  pgtype.Timestamp{Time: value.UpdatedAt, Valid: true},
 	})
 	if err != nil {
+		// No row means the variable does not exist under this app, which is a
+		// not-found rather than a database failure.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/kite-service/internal/store/message.go
+++ b/kite-service/internal/store/message.go
@@ -24,7 +24,7 @@ type MessageInstanceStore interface {
 	MessageInstance(ctx context.Context, appID string, messageID string, instanceID uint64) (*model.MessageInstance, error)
 	MessageInstancesByMessage(ctx context.Context, appID string, messageID string, includeHidden bool) ([]*model.MessageInstance, error)
 	MessageInstanceByDiscordMessageID(ctx context.Context, appID string, discordMessageID string) (*model.MessageInstance, error)
-	CreateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)
+	CreateMessageInstance(ctx context.Context, appID string, instance *model.MessageInstance) (*model.MessageInstance, error)
 	UpdateMessageInstance(ctx context.Context, appID string, instance *model.MessageInstance) (*model.MessageInstance, error)
 	DeleteMessageInstance(ctx context.Context, appID string, messageID string, instanceID uint64) error
 	DeleteMessageInstanceByDiscordMessageID(ctx context.Context, appID string, discordMessageID string) error

--- a/kite-service/internal/store/message.go
+++ b/kite-service/internal/store/message.go
@@ -9,18 +9,23 @@ import (
 type MessageStore interface {
 	MessagesByApp(ctx context.Context, appID string) ([]*model.Message, error)
 	CountMessagesByApp(ctx context.Context, appID string) (int, error)
-	Message(ctx context.Context, id string) (*model.Message, error)
+	Message(ctx context.Context, appID string, id string) (*model.Message, error)
 	CreateMessage(ctx context.Context, variable *model.Message) (*model.Message, error)
 	UpdateMessage(ctx context.Context, variable *model.Message) (*model.Message, error)
 	DeleteMessage(ctx context.Context, id string) error
 }
 
+// MessageInstanceStore scopes every operation by app.
+//
+// message_instances rows carry no app_id, so they are only tenant-safe when
+// looked up through their message. The engine reaches these from Discord
+// interactions, where the caller chose the message being acted on.
 type MessageInstanceStore interface {
-	MessageInstance(ctx context.Context, messageID string, instanceID uint64) (*model.MessageInstance, error)
-	MessageInstancesByMessage(ctx context.Context, messageID string, includeHidden bool) ([]*model.MessageInstance, error)
-	MessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) (*model.MessageInstance, error)
+	MessageInstance(ctx context.Context, appID string, messageID string, instanceID uint64) (*model.MessageInstance, error)
+	MessageInstancesByMessage(ctx context.Context, appID string, messageID string, includeHidden bool) ([]*model.MessageInstance, error)
+	MessageInstanceByDiscordMessageID(ctx context.Context, appID string, discordMessageID string) (*model.MessageInstance, error)
 	CreateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)
-	UpdateMessageInstance(ctx context.Context, instance *model.MessageInstance) (*model.MessageInstance, error)
-	DeleteMessageInstance(ctx context.Context, messageID string, instanceID uint64) error
-	DeleteMessageInstanceByDiscordMessageID(ctx context.Context, discordMessageID string) error
+	UpdateMessageInstance(ctx context.Context, appID string, instance *model.MessageInstance) (*model.MessageInstance, error)
+	DeleteMessageInstance(ctx context.Context, appID string, messageID string, instanceID uint64) error
+	DeleteMessageInstanceByDiscordMessageID(ctx context.Context, appID string, discordMessageID string) error
 }

--- a/kite-service/internal/store/resume_point.go
+++ b/kite-service/internal/store/resume_point.go
@@ -11,5 +11,8 @@ type ResumePointStore interface {
 	CreateResumePoint(ctx context.Context, resumePoint *model.ResumePoint) error
 	DeleteResumePoint(ctx context.Context, id string) error
 	DeleteExpiredResumePoints(ctx context.Context, timestamp time.Time) error
-	ResumePoint(ctx context.Context, id string) (*model.ResumePoint, error)
+	// ResumePoint is scoped by app: the ID reaches us from an interaction's
+	// custom_id, so a resume point belonging to another app has to be
+	// indistinguishable from one that does not exist.
+	ResumePoint(ctx context.Context, appID string, id string) (*model.ResumePoint, error)
 }

--- a/kite-service/internal/store/variable.go
+++ b/kite-service/internal/store/variable.go
@@ -17,11 +17,17 @@ type VariableStore interface {
 	DeleteVariable(ctx context.Context, id string) error
 }
 
+// VariableValueStore scopes every operation by app.
+//
+// variable_values rows carry no app_id, so the variable_id alone is the whole
+// key; the app is what makes it a tenant-safe lookup. Callers reach this from
+// flow node config, where the variable_id is attacker-authored, so the appID
+// must come from the execution context rather than from the same flow.
 type VariableValueStore interface {
-	VariableValues(ctx context.Context, variableID string) ([]*model.VariableValue, error)
-	VariableValue(ctx context.Context, variableID string, scope null.String) (*model.VariableValue, error)
-	SetVariableValue(ctx context.Context, value model.VariableValue) error
-	UpdateVariableValue(ctx context.Context, operation model.VariableValueOperation, value model.VariableValue) (*model.VariableValue, error)
-	DeleteVariableValue(ctx context.Context, variableID string, scope null.String) error
-	DeleteAllVariableValues(ctx context.Context, variableID string) error
+	VariableValues(ctx context.Context, appID string, variableID string) ([]*model.VariableValue, error)
+	VariableValue(ctx context.Context, appID string, variableID string, scope null.String) (*model.VariableValue, error)
+	SetVariableValue(ctx context.Context, appID string, value model.VariableValue) error
+	UpdateVariableValue(ctx context.Context, appID string, operation model.VariableValueOperation, value model.VariableValue) (*model.VariableValue, error)
+	DeleteVariableValue(ctx context.Context, appID string, variableID string, scope null.String) error
+	DeleteAllVariableValues(ctx context.Context, appID string, variableID string) error
 }

--- a/kite-service/pkg/message/data.go
+++ b/kite-service/pkg/message/data.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -11,6 +12,36 @@ type MessageData struct {
 	Embeds          []EmbedData          `json:"embeds,omitempty"`
 	Components      []ComponentRowData   `json:"components,omitempty"`
 	AllowedMentions *AllowedMentionsData `json:"allowed_mentions,omitempty"`
+}
+
+// Validate rejects message data that cannot be sent safely.
+//
+// Deliberately narrow. Message data has always been stored unvalidated, so a
+// broader check here would start rejecting messages that already exist. The
+// only rule is that a component's flow source ID must not claim the custom ID
+// namespace reserved for resume points: a component's Discord custom ID is its
+// flow source ID verbatim, so without this a tenant can author a button whose
+// custom ID addresses a resume point by ID.
+func (m MessageData) Validate() error {
+	for _, row := range m.Components {
+		for _, component := range row.Components {
+			if IsReservedCustomID(component.FlowSourceID) {
+				return fmt.Errorf(
+					"component flow source id must not start with %q", ResumeCustomIDPrefix,
+				)
+			}
+
+			for _, option := range component.Options {
+				if IsReservedCustomID(option.FlowSourceID) {
+					return fmt.Errorf(
+						"select option flow source id must not start with %q", ResumeCustomIDPrefix,
+					)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (m *MessageData) EachString(replace func(s *string) error) error {

--- a/kite-service/pkg/message/data_test.go
+++ b/kite-service/pkg/message/data_test.go
@@ -1,0 +1,95 @@
+package message
+
+import "testing"
+
+// A component's Discord custom ID is its flow source ID verbatim, and the
+// engine routes any custom ID starting with ResumeCustomIDPrefix to a resume
+// point lookup. A tenant authoring their own flow source IDs must therefore not
+// be able to reach that namespace.
+
+func componentMessage(flowSourceID string) MessageData {
+	return MessageData{
+		Components: []ComponentRowData{{
+			Components: []ComponentData{{
+				Type:         2,
+				Label:        "click",
+				FlowSourceID: flowSourceID,
+			}},
+		}},
+	}
+}
+
+func TestMessageDataRejectsReservedComponentFlowSourceID(t *testing.T) {
+	cases := []string{
+		"resume:",
+		"resume:rp-1",
+		"resume:rp-1_0",
+	}
+
+	for _, flowSourceID := range cases {
+		if err := componentMessage(flowSourceID).Validate(); err == nil {
+			t.Errorf("flow source id %q was accepted, want rejected", flowSourceID)
+		}
+	}
+}
+
+func TestMessageDataRejectsReservedSelectOptionFlowSourceID(t *testing.T) {
+	data := MessageData{
+		Components: []ComponentRowData{{
+			Components: []ComponentData{{
+				Type: 3,
+				Options: []ComponentSelectOptionData{{
+					Label:        "option",
+					FlowSourceID: "resume:rp-1_0",
+				}},
+			}},
+		}},
+	}
+
+	if err := data.Validate(); err == nil {
+		t.Error("reserved select option flow source id was accepted, want rejected")
+	}
+}
+
+func TestMessageDataAcceptsOrdinaryFlowSourceIDs(t *testing.T) {
+	cases := []string{
+		"",
+		"src-1",
+		"abc123",
+		"not-resume:rp-1",
+		"RESUME:rp-1", // the prefix check is case sensitive, as is the router
+	}
+
+	for _, flowSourceID := range cases {
+		if err := componentMessage(flowSourceID).Validate(); err != nil {
+			t.Errorf("flow source id %q was rejected: %v", flowSourceID, err)
+		}
+	}
+}
+
+func TestMessageDataAcceptsEmptyData(t *testing.T) {
+	if err := (MessageData{}).Validate(); err != nil {
+		t.Errorf("empty message data was rejected: %v", err)
+	}
+}
+
+// The encoder and decoder have to agree on the reserved prefix, otherwise the
+// validation above guards a namespace nothing actually routes on.
+func TestResumeCustomIDRoundTrip(t *testing.T) {
+	component := CustomIDMessageComponentResumePoint("rp-1", 3)
+	if !IsReservedCustomID(component) {
+		t.Fatalf("%q is not recognised as reserved", component)
+	}
+	id, compID, ok := DecodeCustomIDMessageComponentResumePoint(component)
+	if !ok || id != "rp-1" || compID != 3 {
+		t.Errorf("decoded %q -> (%q, %d, %v), want (rp-1, 3, true)", component, id, compID, ok)
+	}
+
+	modal := CustomIDModalResumePoint("rp-2")
+	if !IsReservedCustomID(modal) {
+		t.Fatalf("%q is not recognised as reserved", modal)
+	}
+	if id, ok := DecodeCustomIDModalResumePoint(modal); !ok || id != "rp-2" {
+		t.Errorf("decoded %q -> (%q, %v), want (rp-2, true)", modal, id, ok)
+	}
+}

--- a/kite-service/pkg/message/helpers.go
+++ b/kite-service/pkg/message/helpers.go
@@ -6,28 +6,41 @@ import (
 	"strings"
 )
 
+// ResumeCustomIDPrefix marks a component custom ID as addressing a resume
+// point. The engine routes any interaction whose custom ID starts with it
+// straight to a resume point lookup, so the prefix is reserved: a component's
+// own custom ID comes from its flow source ID, which is authored by the tenant,
+// and must never be able to land in this namespace.
+const ResumeCustomIDPrefix = "resume:"
+
+// IsReservedCustomID reports whether a custom ID would be read as addressing a
+// resume point rather than the component it is attached to.
+func IsReservedCustomID(customID string) bool {
+	return strings.HasPrefix(customID, ResumeCustomIDPrefix)
+}
+
 func CustomIDModalResumePoint(resumePointID string) string {
-	return fmt.Sprintf("resume:%s", resumePointID)
+	return ResumeCustomIDPrefix + resumePointID
 }
 
 func DecodeCustomIDModalResumePoint(customID string) (string, bool) {
-	if !strings.HasPrefix(customID, "resume:") {
+	if !strings.HasPrefix(customID, ResumeCustomIDPrefix) {
 		return "", false
 	}
 
-	return customID[len("resume:"):], true
+	return customID[len(ResumeCustomIDPrefix):], true
 }
 
 func CustomIDMessageComponentResumePoint(resumePointID string, componentID int) string {
-	return fmt.Sprintf("resume:%s_%d", resumePointID, componentID)
+	return fmt.Sprintf("%s%s_%d", ResumeCustomIDPrefix, resumePointID, componentID)
 }
 
 func DecodeCustomIDMessageComponentResumePoint(customID string) (string, int, bool) {
-	if !strings.HasPrefix(customID, "resume:") {
+	if !strings.HasPrefix(customID, ResumeCustomIDPrefix) {
 		return "", 0, false
 	}
 
-	value := customID[len("resume:"):]
+	value := customID[len(ResumeCustomIDPrefix):]
 
 	parts := strings.Split(value, "_")
 	if len(parts) != 2 {

--- a/kite-service/pkg/message/helpers.go
+++ b/kite-service/pkg/message/helpers.go
@@ -16,7 +16,8 @@ const ResumeCustomIDPrefix = "resume:"
 // IsReservedCustomID reports whether a custom ID would be read as addressing a
 // resume point rather than the component it is attached to.
 func IsReservedCustomID(customID string) bool {
-	return strings.HasPrefix(customID, ResumeCustomIDPrefix)
+	_, ok := strings.CutPrefix(customID, ResumeCustomIDPrefix)
+	return ok
 }
 
 func CustomIDModalResumePoint(resumePointID string) string {
@@ -24,11 +25,7 @@ func CustomIDModalResumePoint(resumePointID string) string {
 }
 
 func DecodeCustomIDModalResumePoint(customID string) (string, bool) {
-	if !strings.HasPrefix(customID, ResumeCustomIDPrefix) {
-		return "", false
-	}
-
-	return customID[len(ResumeCustomIDPrefix):], true
+	return strings.CutPrefix(customID, ResumeCustomIDPrefix)
 }
 
 func CustomIDMessageComponentResumePoint(resumePointID string, componentID int) string {
@@ -36,11 +33,10 @@ func CustomIDMessageComponentResumePoint(resumePointID string, componentID int) 
 }
 
 func DecodeCustomIDMessageComponentResumePoint(customID string) (string, int, bool) {
-	if !strings.HasPrefix(customID, ResumeCustomIDPrefix) {
+	value, ok := strings.CutPrefix(customID, ResumeCustomIDPrefix)
+	if !ok {
 		return "", 0, false
 	}
-
-	value := customID[len(ResumeCustomIDPrefix):]
 
 	parts := strings.Split(value, "_")
 	if len(parts) != 2 {


### PR DESCRIPTION
Follow-up to #329. Independent of it — branched from `main`, no overlapping hunks, either can merge first.

## Why

Tenant isolation is enforced in `internal/api/access/middleware.go`: it resolves `{appID}`, loads the resource, and compares. That works for the API. The engine never goes through it.

The store layer underneath is uniformly keyed by ID alone, so it carries no isolation of its own:

- `variable_values` and `message_instances` have no `app_id` column at all — the only path to an app is a join through `variables`/`messages`, which nothing performed.
- `GetMessage`, `ResumePoint` and friends were `WHERE id = $1`.

The IDs the engine acts on come from flow node config (`variable_id`, `message_template_id`) and from Discord interaction custom IDs. None of those is evidence of ownership, and flow JSON moves between apps through the import/export endpoints, so the IDs aren't private either.

## What changed

**Queries** — value and instance queries join through their parent to reach `app_id`; `GetMessage` and `ResumePoint` take the app directly, since both tables have their own `app_id`. The two writes make the app check part of the write rather than a separate round trip: `SetVariableValue` and `CreateMessageInstance` are `INSERT ... SELECT FROM variables/messages`, so if the parent isn't the app's, the select is empty, nothing is inserted, and `:one` surfaces it as not-found. `GetVariableValueForUpdate` uses `FOR UPDATE OF variable_values` so the join doesn't also lock the `variables` row.

**Providers** — `VariableProvider` and `MessageTemplateProvider` now carry the executing app's ID, the way `LogProvider` and `ResumePointProvider` already did, and pass it to every store call.

**`MessageAccess`** — scopes in the query instead of comparing afterwards, so another app's message is not-found rather than forbidden. Removes the `// We assume that app access has already been checked` pattern for this one.

**`resumeFlow`** — the resume point lookup is scoped by app. The command and event-listener branches already failed closed by resolving against the app's own in-memory maps; the message-instance branch reads from the database, and a resume point carries the `FlowState` the flow suspended with. Scoped in the query rather than compared after loading, so the foreign row (`FlowState` included) never reaches the process.

**Custom ID namespace** — a component's Discord custom ID is its `flow_source_id` verbatim, and the engine routes any custom ID with the resume prefix to a resume point lookup. Those two namespaces could overlap, so `flow_source_id` is now rejected at save time if it claims the reserved prefix. That also wires up `MessageData` validation, which the create/update requests never had. The prefix is a shared constant now instead of three copies of a literal.

No schema change — `variables.app_id` and `messages.app_id` are already the authority, so this is a join, not a new column plus a backfill.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` clean. Queries regenerated with `sqlc generate`, not hand-edited.

Query scoping has no live-database coverage in this repo, so `queries_scoping_test.go` asserts it against the `.sql` files themselves — a regenerate would otherwise carry a dropped join straight through into the generated code. It's default-deny rather than a list of query names: any block touching `variable_values` or `message_instances` must also name `app_id`, so a query added later is covered the day it's written instead of when someone remembers to update the test. Comments are stripped before the check, so prose mentioning `app_id` can't pass for a predicate. Exemptions are explicit and need a reason.

`resume_test.go` covers the ownership check in both directions; the positive case is the control that keeps the negative one from passing vacuously. Its stub embeds `store.ResumePointStore` so any method `resumeFlow` doesn't call panics instead of quietly returning a zero value.

## Review notes

- `Message`, `MessageInstance*`, `ResumePoint`, and the variable value methods gained an `appID` parameter, which is most of the diff's line count. Every call site had one available.
- The one exemption in the scoping test is `GetVariable`: it left-joins `variable_values` only to count the variable's own children, so no child row is reachable by its own ID there. Whether the parent lookup is scoped is `VariableAccess`'s concern.
- `GetVariable` / `UpdateVariable` / `DeleteVariable` are still ID-only. They're only reachable via `VariableAccess`, which does compare — I left them rather than widen this further, so `VariableAccess` and `MessageAccess` now use different patterns. Happy to make them consistent if you'd rather.
- `HandleMessageDeleteEvent` now scopes its cleanup delete by app. Previously any app seeing a `MESSAGE_DELETE` deleted the row for that Discord message regardless of owner.
