### PR TITLE
fix(billing): keep subscription state in sync with LemonSqueezy

### DIFF
--- a/kite-service/internal/api/handler/billing/webhook.go
+++ b/kite-service/internal/api/handler/billing/webhook.go
@@ -14,6 +14,21 @@ import (
 	"gopkg.in/guregu/null.v4"
 )
 
+// subscriptionEventNames are the events whose data object is a subscription,
+// and which therefore carry a status transition we need to persist. The
+// subscription_payment_* events are deliberately absent: their data object is a
+// subscription invoice, so its ID and status belong to the invoice, not the
+// subscription.
+var subscriptionEventNames = map[string]bool{
+	lemonsqueezy.WebhookEventSubscriptionCreated:   true,
+	lemonsqueezy.WebhookEventSubscriptionUpdated:   true,
+	lemonsqueezy.WebhookEventSubscriptionCancelled: true,
+	lemonsqueezy.WebhookEventSubscriptionResumed:   true,
+	lemonsqueezy.WebhookEventSubscriptionExpired:   true,
+	lemonsqueezy.WebhookEventSubscriptionPaused:    true,
+	lemonsqueezy.WebhookEventSubscriptionUnpaused:  true,
+}
+
 func (h *BillingHandler) HandleBillingWebhook(c *handler.Context, body json.RawMessage) (*wire.BillingWebhookResponse, error) {
 	eventName := c.Header("X-Event-Name")
 	signature := c.Header("X-Signature")
@@ -22,8 +37,12 @@ func (h *BillingHandler) HandleBillingWebhook(c *handler.Context, body json.RawM
 		return nil, fmt.Errorf("failed to verify webhook signature")
 	}
 
-	if eventName != lemonsqueezy.WebhookEventSubscriptionCreated && eventName != lemonsqueezy.WebhookEventSubscriptionUpdated {
-		return nil, fmt.Errorf("unsupported event name: %s", eventName)
+	if !subscriptionEventNames[eventName] {
+		// Everything else (orders, license keys, and the subscription_payment_*
+		// events, which carry an invoice rather than a subscription) is
+		// acknowledged and ignored. Returning an error here would make
+		// LemonSqueezy retry and eventually mark the endpoint as failing.
+		return &wire.BillingWebhookResponse{}, nil
 	}
 
 	var req wire.BillingWebhookRequest
@@ -34,11 +53,22 @@ func (h *BillingHandler) HandleBillingWebhook(c *handler.Context, body json.RawM
 	appID, _ := req.Meta.CustomData["app_id"].(string)
 	userID, _ := req.Meta.CustomData["user_id"].(string)
 	if userID == "" {
-		slog.Error(
-			"Subscription created webhook received without user_id in metadata",
-			slog.String("ls_subscription_id", req.Data.ID),
-		)
-		return nil, fmt.Errorf("user_id is required in metadata")
+		// Lifecycle events raised outside of checkout (a cancellation from the
+		// customer portal, for example) can arrive without the custom data we
+		// set at checkout. As long as we have seen the subscription before we
+		// can recover the owner from it rather than dropping the event.
+		existing, err := h.subscriptionStore.SubscriptionByLemonSqueezyID(c.Context(), req.Data.ID)
+		if err != nil {
+			slog.Error(
+				"Subscription webhook received without user_id in metadata for an unknown subscription",
+				slog.String("event_name", eventName),
+				slog.String("ls_subscription_id", req.Data.ID),
+				slog.String("error", err.Error()),
+			)
+			return nil, fmt.Errorf("user_id is required in metadata: %w", err)
+		}
+
+		userID = existing.UserID
 	}
 
 	sub := req.Data.Attributes
@@ -113,7 +143,7 @@ func (h *BillingHandler) HandleBillingWebhook(c *handler.Context, body json.RawM
 		}
 	} else {
 		// We don't have the app ID, but there might be an entitlement anyway, so we update that
-		_, err := h.entitlementStore.UpdateSubscriptionEntitlement(c.Context(), entitlement)
+		err := h.entitlementStore.UpdateSubscriptionEntitlement(c.Context(), entitlement)
 		if err != nil {
 			slog.Error(
 				"Failed to update subscription entitlement",

--- a/kite-service/internal/db/postgres/pgmodel/entitlements.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/entitlements.sql.go
@@ -124,12 +124,12 @@ func (q *Queries) GetEntitlements(ctx context.Context, appID string) ([]Entitlem
 	return items, nil
 }
 
-const updateSubscriptionEntitlement = `-- name: UpdateSubscriptionEntitlement :one
+const updateSubscriptionEntitlement = `-- name: UpdateSubscriptionEntitlement :exec
 UPDATE entitlements SET
     plan_id = $2,
     updated_at = $3,
     ends_at = $4
-WHERE subscription_id = $1 RETURNING id, type, subscription_id, app_id, plan_id, created_at, updated_at, ends_at
+WHERE subscription_id = $1
 `
 
 type UpdateSubscriptionEntitlementParams struct {
@@ -139,25 +139,17 @@ type UpdateSubscriptionEntitlementParams struct {
 	EndsAt         pgtype.Timestamp
 }
 
-func (q *Queries) UpdateSubscriptionEntitlement(ctx context.Context, arg UpdateSubscriptionEntitlementParams) (Entitlement, error) {
-	row := q.db.QueryRow(ctx, updateSubscriptionEntitlement,
+// Updates every entitlement held by the subscription. :exec, not :one, because
+// a webhook can arrive for a subscription that has no entitlement yet (no
+// app_id in the checkout metadata), and no rows to update is not an error.
+func (q *Queries) UpdateSubscriptionEntitlement(ctx context.Context, arg UpdateSubscriptionEntitlementParams) error {
+	_, err := q.db.Exec(ctx, updateSubscriptionEntitlement,
 		arg.SubscriptionID,
 		arg.PlanID,
 		arg.UpdatedAt,
 		arg.EndsAt,
 	)
-	var i Entitlement
-	err := row.Scan(
-		&i.ID,
-		&i.Type,
-		&i.SubscriptionID,
-		&i.AppID,
-		&i.PlanID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.EndsAt,
-	)
-	return i, err
+	return err
 }
 
 const upsertSubscriptionEntitlement = `-- name: UpsertSubscriptionEntitlement :one

--- a/kite-service/internal/db/postgres/pgmodel/subscriptions.sql.go
+++ b/kite-service/internal/db/postgres/pgmodel/subscriptions.sql.go
@@ -80,6 +80,34 @@ func (q *Queries) GetSubscription(ctx context.Context, id string) (Subscription,
 	return i, err
 }
 
+const getSubscriptionByLemonSqueezyID = `-- name: GetSubscriptionByLemonSqueezyID :one
+SELECT id, display_name, source, status, status_formatted, created_at, updated_at, renews_at, trial_ends_at, ends_at, user_id, lemonsqueezy_subscription_id, lemonsqueezy_customer_id, lemonsqueezy_order_id, lemonsqueezy_product_id, lemonsqueezy_variant_id FROM subscriptions WHERE lemonsqueezy_subscription_id = $1
+`
+
+func (q *Queries) GetSubscriptionByLemonSqueezyID(ctx context.Context, lemonsqueezySubscriptionID pgtype.Text) (Subscription, error) {
+	row := q.db.QueryRow(ctx, getSubscriptionByLemonSqueezyID, lemonsqueezySubscriptionID)
+	var i Subscription
+	err := row.Scan(
+		&i.ID,
+		&i.DisplayName,
+		&i.Source,
+		&i.Status,
+		&i.StatusFormatted,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.RenewsAt,
+		&i.TrialEndsAt,
+		&i.EndsAt,
+		&i.UserID,
+		&i.LemonsqueezySubscriptionID,
+		&i.LemonsqueezyCustomerID,
+		&i.LemonsqueezyOrderID,
+		&i.LemonsqueezyProductID,
+		&i.LemonsqueezyVariantID,
+	)
+	return i, err
+}
+
 const getSubscriptions = `-- name: GetSubscriptions :many
 SELECT id, display_name, source, status, status_formatted, created_at, updated_at, renews_at, trial_ends_at, ends_at, user_id, lemonsqueezy_subscription_id, lemonsqueezy_customer_id, lemonsqueezy_order_id, lemonsqueezy_product_id, lemonsqueezy_variant_id FROM subscriptions WHERE user_id = $1 ORDER BY created_at DESC
 `

--- a/kite-service/internal/db/postgres/queries/entitlements.sql
+++ b/kite-service/internal/db/postgres/queries/entitlements.sql
@@ -29,9 +29,12 @@ ON CONFLICT (subscription_id, app_id) DO UPDATE SET
     ends_at = EXCLUDED.ends_at
 RETURNING *;
 
--- name: UpdateSubscriptionEntitlement :one
+-- Updates every entitlement held by the subscription. :exec, not :one, because
+-- a webhook can arrive for a subscription that has no entitlement yet (no
+-- app_id in the checkout metadata), and no rows to update is not an error.
+-- name: UpdateSubscriptionEntitlement :exec
 UPDATE entitlements SET
     plan_id = $2,
     updated_at = $3,
     ends_at = $4
-WHERE subscription_id = $1 RETURNING *;
+WHERE subscription_id = $1;

--- a/kite-service/internal/db/postgres/queries/subscriptions.sql
+++ b/kite-service/internal/db/postgres/queries/subscriptions.sql
@@ -10,6 +10,9 @@ SELECT * FROM subscriptions ORDER BY created_at DESC;
 -- name: GetSubscription :one
 SELECT * FROM subscriptions WHERE id = $1;
 
+-- name: GetSubscriptionByLemonSqueezyID :one
+SELECT * FROM subscriptions WHERE lemonsqueezy_subscription_id = $1;
+
 -- name: UpsertLemonSqueezySubscription :one
 INSERT INTO subscriptions (
     id,

--- a/kite-service/internal/db/postgres/store_entitlement.go
+++ b/kite-service/internal/db/postgres/store_entitlement.go
@@ -78,18 +78,13 @@ func (c *Client) UpsertSubscriptionEntitlement(ctx context.Context, entitlement 
 	return rowToEntitlement(row), nil
 }
 
-func (c *Client) UpdateSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error) {
-	row, err := c.Q.UpdateSubscriptionEntitlement(ctx, pgmodel.UpdateSubscriptionEntitlementParams{
+func (c *Client) UpdateSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) error {
+	return c.Q.UpdateSubscriptionEntitlement(ctx, pgmodel.UpdateSubscriptionEntitlementParams{
 		SubscriptionID: pgtype.Text{String: entitlement.SubscriptionID.String, Valid: entitlement.SubscriptionID.Valid},
 		PlanID:         entitlement.PlanID,
 		UpdatedAt:      pgtype.Timestamp{Time: entitlement.UpdatedAt, Valid: true},
 		EndsAt:         pgtype.Timestamp{Time: entitlement.EndsAt.Time, Valid: entitlement.EndsAt.Valid},
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return rowToEntitlement(row), nil
 }
 
 func rowToEntitlement(row pgmodel.Entitlement) *model.Entitlement {

--- a/kite-service/internal/db/postgres/store_subscription.go
+++ b/kite-service/internal/db/postgres/store_subscription.go
@@ -2,10 +2,13 @@ package postgres
 
 import (
 	"context"
+	"errors"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/kitecloud/kite/kite-service/internal/db/postgres/pgmodel"
 	"github.com/kitecloud/kite/kite-service/internal/model"
+	"github.com/kitecloud/kite/kite-service/internal/store"
 	"gopkg.in/guregu/null.v4"
 )
 
@@ -54,6 +57,18 @@ func (c *Client) AllSubscriptions(ctx context.Context) ([]*model.Subscription, e
 func (c *Client) Subscription(ctx context.Context, subscriptionID string) (*model.Subscription, error) {
 	row, err := c.Q.GetSubscription(ctx, subscriptionID)
 	if err != nil {
+		return nil, err
+	}
+
+	return rowToSubscription(row), nil
+}
+
+func (c *Client) SubscriptionByLemonSqueezyID(ctx context.Context, lemonSqueezyID string) (*model.Subscription, error) {
+	row, err := c.Q.GetSubscriptionByLemonSqueezyID(ctx, pgtype.Text{String: lemonSqueezyID, Valid: true})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/kite-service/internal/store/entitlement.go
+++ b/kite-service/internal/store/entitlement.go
@@ -13,5 +13,7 @@ type EntitlementStore interface {
 	// ActiveEntitlementsForApps is the batch form, keyed by app ID.
 	ActiveEntitlementsForApps(ctx context.Context, appIDs []string, now time.Time) (map[string][]*model.Entitlement, error)
 	UpsertSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error)
-	UpdateSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) (*model.Entitlement, error)
+	// UpdateSubscriptionEntitlement updates every entitlement the subscription
+	// holds. A subscription with no entitlements is not an error.
+	UpdateSubscriptionEntitlement(ctx context.Context, entitlement model.Entitlement) error
 }

--- a/kite-service/internal/store/subscription.go
+++ b/kite-service/internal/store/subscription.go
@@ -11,5 +11,8 @@ type SubscriptionStore interface {
 	SubscriptionsByAppID(ctx context.Context, appID string) ([]*model.Subscription, error)
 	AllSubscriptions(ctx context.Context) ([]*model.Subscription, error)
 	Subscription(ctx context.Context, subscriptionID string) (*model.Subscription, error)
+	// SubscriptionByLemonSqueezyID returns ErrNotFound if we have never seen the
+	// subscription before.
+	SubscriptionByLemonSqueezyID(ctx context.Context, lemonSqueezyID string) (*model.Subscription, error)
 	UpsertLemonSqueezySubscription(ctx context.Context, sub model.Subscription) (*model.Subscription, error)
 }

--- a/kite-web/src/components/app/AppPricingList.tsx
+++ b/kite-web/src/components/app/AppPricingList.tsx
@@ -13,12 +13,13 @@ import { useAppSubscriptions, useBillingPlans } from "@/lib/hooks/api";
 import { ReactNode, useMemo } from "react";
 import { useLemonSqueezyCheckout } from "@/lib/hooks/lemonsqueezy";
 import { formatNumber } from "@/lib/utils";
+import { isSubscriptionActive } from "@/lib/subscriptions";
 
 export default function AppPricingList() {
   const subscriptions = useAppSubscriptions();
 
-  const activeSubscriptions = subscriptions?.filter(
-    (subscription) => subscription!.status !== "expired"
+  const activeSubscriptions = subscriptions?.filter((subscription) =>
+    isSubscriptionActive(subscription!)
   );
 
   const plans = useBillingPlans();

--- a/kite-web/src/components/app/AppSubscriptionListEntry.tsx
+++ b/kite-web/src/components/app/AppSubscriptionListEntry.tsx
@@ -12,6 +12,7 @@ import {
   useLemonSqueezyCustomerPortal,
   useLemonSqueezyUpdatePaymentMethod,
 } from "@/lib/hooks/lemonsqueezy";
+import { isSubscriptionActive } from "@/lib/subscriptions";
 
 export default function AppSubscriptionListEntry({
   subscription,
@@ -41,7 +42,9 @@ export default function AppSubscriptionListEntry({
           </div>
           <div>
             <Badge
-              variant={subscription.status !== "ended" ? "default" : "outline"}
+              variant={
+                isSubscriptionActive(subscription) ? "default" : "outline"
+              }
             >
               {subscription.status_formatted}
             </Badge>

--- a/kite-web/src/lib/subscriptions.ts
+++ b/kite-web/src/lib/subscriptions.ts
@@ -1,0 +1,10 @@
+import { Subscription } from "./types/wire.gen";
+
+// LemonSqueezy subscription statuses that still grant (or will grant) access.
+// Anything else - "cancelled", "expired", "unpaid", "paused" - leaves the app
+// without an entitlement, so the plan must be purchasable again.
+const ACTIVE_STATUSES = ["on_trial", "active", "past_due"];
+
+export function isSubscriptionActive(subscription: Subscription): boolean {
+  return ACTIVE_STATUSES.includes(subscription.status);
+}


### PR DESCRIPTION
Users could not resubscribe after cancelling, and some lost premium while still being charged.

**1 of 4 in a stack.** Merge in order: this → `billing-nullable-renews-at` → `billing-plan-switching` → `billing-reconcile`.

## Causes

**The pricing list treated every status except `expired` as active.** LemonSqueezy sets `cancelled` on cancellation, so the plan still rendered a disabled "Current Plan" button and there was no way to buy again.

**The webhook rejected every event other than `subscription_created` and `subscription_updated`, returning 500.** Cancellations, expiries and pauses never reached the database, so a row stuck at `cancelled` never reached `expired` and the button stayed stuck. Routine `subscription_payment_success` deliveries also kept the endpoint in a failing state.

`subscription_payment_*` stays ignored on purpose — those carry a subscription *invoice*, not a subscription, so feeding them to the upsert would write invoice IDs and `"paid"` into subscription rows.

**The no-`app_id` path used a `:one` query.** A subscription with no entitlement failed with `ErrNoRows`, LemonSqueezy retried and gave up, and the entitlement's `ends_at` never advanced — premium lapsed while the card was still being charged. Now `:exec`, updating every entitlement the subscription holds.

Lifecycle events raised from the customer portal can arrive without the custom data set at checkout, so the owner is recovered from the stored subscription rather than dropping the event.

## Action required in LemonSqueezy

This PR is inert until the webhook's event checkboxes are updated in Settings → Webhooks. Enable `subscription_cancelled`, `subscription_expired`, `subscription_paused`, `subscription_unpaused`, `subscription_resumed`. Leave the `subscription_payment_*` ones off.

## Testing

`go build`, `go vet`, `go test`, `tsc --noEmit` and `next lint` all clean.