### PR TITLE
feat(billing): switch plans on the existing subscription

### DIFF
--- a/kite-service/internal/api/handler/billing/subscription.go
+++ b/kite-service/internal/api/handler/billing/subscription.go
@@ -2,6 +2,7 @@ package billing
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/NdoleStudio/lemonsqueezy-go"
@@ -93,7 +94,15 @@ func (h *BillingHandler) HandleSubscriptionPlanUpdate(c *handler.Context, req wi
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to update subscription in LemonSqueezy: %w", err)
+		// Unexpected errors are returned to the client verbatim, so keep the
+		// provider's name out of a message the user will read.
+		slog.Error(
+			"Failed to update subscription with the billing provider",
+			slog.String("subscription_id", subscription.ID),
+			slog.String("ls_subscription_id", subscription.LemonsqueezySubscriptionID.String),
+			slog.String("error", err.Error()),
+		)
+		return nil, handler.ErrInternal("Failed to switch plan with our payment provider, please try again")
 	}
 
 	// LemonSqueezy also sends a subscription_updated webhook, but we cannot rely
@@ -128,7 +137,13 @@ func (h *BillingHandler) HandleSubscriptionManage(c *handler.Context) (*wire.Sub
 
 	sub, _, err := h.client.Subscriptions.Get(c.Context(), subscription.LemonsqueezySubscriptionID.String)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get subscription from LemonSqueezy: %w", err)
+		slog.Error(
+			"Failed to get subscription from the billing provider",
+			slog.String("subscription_id", subscription.ID),
+			slog.String("ls_subscription_id", subscription.LemonsqueezySubscriptionID.String),
+			slog.String("error", err.Error()),
+		)
+		return nil, handler.ErrInternal("Failed to reach our payment provider, please try again")
 	}
 
 	return &wire.SubscriptionManageResponse{

--- a/kite-service/internal/api/handler/billing/subscription.go
+++ b/kite-service/internal/api/handler/billing/subscription.go
@@ -2,9 +2,12 @@ package billing
 
 import (
 	"fmt"
+	"strconv"
 
+	"github.com/NdoleStudio/lemonsqueezy-go"
 	"github.com/kitecloud/kite/kite-service/internal/api/handler"
 	"github.com/kitecloud/kite/kite-service/internal/api/wire"
+	"github.com/kitecloud/kite/kite-service/internal/model"
 )
 
 func (h *BillingHandler) HandleAppSubscriptionList(c *handler.Context) (*wire.SubscriptionListResponse, error) {
@@ -19,6 +22,93 @@ func (h *BillingHandler) HandleAppSubscriptionList(c *handler.Context) (*wire.Su
 	}
 
 	return &res, nil
+}
+
+// activeStatuses are the LemonSqueezy statuses a subscription can be switched
+// from. Cancelled, expired, unpaid and paused subscriptions are not billed on a
+// schedule anymore, so a plan change would not take effect; those go back
+// through checkout or the customer portal instead.
+var activeStatuses = map[string]bool{
+	"on_trial": true,
+	"active":   true,
+	"past_due": true,
+}
+
+func (h *BillingHandler) HandleSubscriptionPlanUpdate(c *handler.Context, req wire.SubscriptionPlanUpdateRequest) (*wire.SubscriptionPlanUpdateResponse, error) {
+	// Scoped to the app so that a subscription entitling some other app cannot
+	// be made to grant an entitlement here as well.
+	subscriptions, err := h.subscriptionStore.SubscriptionsByAppID(c.Context(), c.App.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subscriptions: %w", err)
+	}
+
+	subscriptionID := c.Param("subscriptionID")
+	var subscription *model.Subscription
+	for _, s := range subscriptions {
+		if s.ID == subscriptionID {
+			subscription = s
+			break
+		}
+	}
+	if subscription == nil {
+		return nil, handler.ErrNotFound("unknown_subscription", "The app has no such subscription")
+	}
+
+	if subscription.UserID != c.Session.UserID {
+		return nil, handler.ErrForbidden("missing_access", "You do not have access to this subscription")
+	}
+
+	if !subscription.LemonsqueezySubscriptionID.Valid {
+		return nil, handler.ErrNotFound("unmanageable_subscription", "Subscription can not be managed")
+	}
+
+	if !activeStatuses[subscription.Status] {
+		return nil, handler.ErrBadRequest(
+			"inactive_subscription",
+			"Only an active subscription can be switched to a different plan",
+		)
+	}
+
+	plan := h.planManager.PlanByLemonSqueezyVariantID(req.LemonSqueezyVariantID)
+	if plan == nil || plan.Hidden {
+		return nil, handler.ErrBadRequest("unknown_plan", "There is no plan with that variant ID")
+	}
+
+	if subscription.LemonsqueezyVariantID.String == req.LemonSqueezyVariantID {
+		return nil, handler.ErrBadRequest("plan_unchanged", "The subscription is already on that plan")
+	}
+
+	variantID, err := strconv.Atoi(req.LemonSqueezyVariantID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert variant ID to int: %w", err)
+	}
+
+	// Prorated and invoiced right away, so the new plan's features apply from
+	// this moment rather than from the next renewal.
+	res, _, err := h.client.Subscriptions.Update(c.Context(), &lemonsqueezy.SubscriptionUpdateParams{
+		ID: subscription.LemonsqueezySubscriptionID.String,
+		Attributes: lemonsqueezy.SubscriptionUpdateParamsAttributes{
+			VariantID:          variantID,
+			InvoiceImmediately: true,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update subscription in LemonSqueezy: %w", err)
+	}
+
+	// LemonSqueezy also sends a subscription_updated webhook, but we cannot rely
+	// on it having arrived by the time the client refetches.
+	updated, err := h.syncSubscription(c.Context(), subscriptionSyncFromLemonSqueezy(
+		res.Data.ID,
+		subscription.UserID,
+		c.App.ID,
+		res.Data.Attributes,
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return wire.SubscriptionToWire(updated, c.Session.UserID), nil
 }
 
 func (h *BillingHandler) HandleSubscriptionManage(c *handler.Context) (*wire.SubscriptionManageResponse, error) {

--- a/kite-service/internal/api/handler/billing/sync.go
+++ b/kite-service/internal/api/handler/billing/sync.go
@@ -1,0 +1,143 @@
+package billing
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/NdoleStudio/lemonsqueezy-go"
+	"github.com/kitecloud/kite/kite-service/internal/model"
+	"github.com/kitecloud/kite/kite-service/internal/util"
+	"gopkg.in/guregu/null.v4"
+)
+
+// subscriptionSync is the subset of a LemonSqueezy subscription we persist. It
+// exists because the webhook payload and the API client return the same
+// subscription in two different shapes.
+type subscriptionSync struct {
+	LemonSqueezySubscriptionID string
+	UserID                     string
+	// AppID is empty when we cannot tell which app the subscription belongs to,
+	// which is the case for webhooks that arrive without our checkout metadata.
+	AppID string
+
+	ProductName     string
+	Status          string
+	StatusFormatted string
+
+	LemonSqueezyCustomerID string
+	LemonSqueezyOrderID    string
+	LemonSqueezyProductID  string
+	LemonSqueezyVariantID  string
+
+	RenewsAt    null.Time
+	TrialEndsAt null.Time
+	EndsAt      null.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// subscriptionSyncFromLemonSqueezy adapts a subscription as returned by the
+// LemonSqueezy API, which uses pointers where the webhook payload uses nulls.
+func subscriptionSyncFromLemonSqueezy(
+	lemonSqueezySubscriptionID string,
+	userID string,
+	appID string,
+	sub lemonsqueezy.Subscription,
+) subscriptionSync {
+	return subscriptionSync{
+		LemonSqueezySubscriptionID: lemonSqueezySubscriptionID,
+		UserID:                     userID,
+		AppID:                      appID,
+		ProductName:                sub.ProductName,
+		Status:                     sub.Status,
+		StatusFormatted:            sub.StatusFormatted,
+		LemonSqueezyCustomerID:     strconv.Itoa(sub.CustomerID),
+		LemonSqueezyOrderID:        strconv.Itoa(sub.OrderID),
+		LemonSqueezyProductID:      strconv.Itoa(sub.ProductID),
+		LemonSqueezyVariantID:      strconv.Itoa(sub.VariantID),
+		// The client decodes renews_at into a plain time.Time, so a null from
+		// LemonSqueezy arrives as the zero value rather than as an absent date.
+		RenewsAt:                   null.NewTime(sub.RenewsAt, !sub.RenewsAt.IsZero()),
+		TrialEndsAt:                null.TimeFromPtr(sub.TrialEndsAt),
+		EndsAt:                     null.TimeFromPtr(sub.EndsAt),
+		CreatedAt:                  sub.CreatedAt,
+		UpdatedAt:                  sub.UpdatedAt,
+	}
+}
+
+// syncSubscription stores the subscription and brings its entitlements in line
+// with the plan and dates LemonSqueezy reports.
+func (h *BillingHandler) syncSubscription(ctx context.Context, in subscriptionSync) (*model.Subscription, error) {
+	subscription, err := h.subscriptionStore.UpsertLemonSqueezySubscription(ctx, model.Subscription{
+		ID:                         util.UniqueID(),
+		DisplayName:                in.ProductName,
+		Source:                     model.SubscriptionSourceLemonSqueezy,
+		Status:                     in.Status,
+		StatusFormatted:            in.StatusFormatted,
+		RenewsAt:                   in.RenewsAt,
+		TrialEndsAt:                in.TrialEndsAt,
+		EndsAt:                     in.EndsAt,
+		CreatedAt:                  in.CreatedAt,
+		UpdatedAt:                  in.UpdatedAt,
+		UserID:                     in.UserID,
+		LemonsqueezySubscriptionID: null.StringFrom(in.LemonSqueezySubscriptionID),
+		LemonsqueezyCustomerID:     null.StringFrom(in.LemonSqueezyCustomerID),
+		LemonsqueezyOrderID:        null.StringFrom(in.LemonSqueezyOrderID),
+		LemonsqueezyProductID:      null.StringFrom(in.LemonSqueezyProductID),
+		LemonsqueezyVariantID:      null.StringFrom(in.LemonSqueezyVariantID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to upsert subscription: %w", err)
+	}
+
+	plan := h.planManager.PlanByLemonSqueezyProductID(in.LemonSqueezyProductID)
+	if plan == nil {
+		return nil, fmt.Errorf("failed to find plan for product ID %s", in.LemonSqueezyProductID)
+	}
+
+	entitlement := model.Entitlement{
+		ID:             util.UniqueID(),
+		Type:           "subscription",
+		SubscriptionID: null.StringFrom(subscription.ID),
+		AppID:          in.AppID,
+		PlanID:         plan.ID,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+		EndsAt:         entitlementEndsAt(in.RenewsAt, in.EndsAt),
+	}
+
+	if in.AppID != "" {
+		// Create a new entitlement or update the existing one
+		if _, err := h.entitlementStore.UpsertSubscriptionEntitlement(ctx, entitlement); err != nil {
+			return nil, fmt.Errorf("failed to upsert subscription entitlement: %w", err)
+		}
+	} else {
+		// We don't have the app ID, but there might be an entitlement anyway, so we update that
+		if err := h.entitlementStore.UpdateSubscriptionEntitlement(ctx, entitlement); err != nil {
+			return nil, fmt.Errorf("failed to update subscription entitlement: %w", err)
+		}
+	}
+
+	return subscription, nil
+}
+
+// entitlementEndsAt derives the entitlement end date from the subscription's
+// dates. renews_at is the default, so an entitlement never outlives the period
+// that has been paid for. ends_at wins when it comes first, which is the case
+// for a cancelled subscription serving out its remaining period.
+func entitlementEndsAt(renewsAt null.Time, endsAt null.Time) null.Time {
+	result := renewsAt
+	if endsAt.Valid && (!result.Valid || endsAt.Time.Before(result.Time)) {
+		result = endsAt
+	}
+	if !result.Valid {
+		// Neither date is set, which means the subscription will not renew and
+		// has no remaining paid period - a paused one, for example. Ending the
+		// entitlement now keeps it out of ActiveEntitlements.
+		result = null.TimeFrom(time.Now().UTC())
+	}
+
+	return result
+}

--- a/kite-service/internal/api/handler/billing/sync_test.go
+++ b/kite-service/internal/api/handler/billing/sync_test.go
@@ -1,0 +1,46 @@
+package billing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/guregu/null.v4"
+)
+
+func TestEntitlementEndsAt(t *testing.T) {
+	renews := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	ends := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+
+	t.Run("renews_at is used while the subscription keeps renewing", func(t *testing.T) {
+		got := entitlementEndsAt(null.TimeFrom(renews), null.Time{})
+		assert.Equal(t, null.TimeFrom(renews), got)
+	})
+
+	t.Run("ends_at wins when the subscription ends before the next renewal", func(t *testing.T) {
+		got := entitlementEndsAt(null.TimeFrom(renews), null.TimeFrom(ends))
+		assert.Equal(t, null.TimeFrom(ends), got)
+	})
+
+	t.Run("renews_at wins when it comes first", func(t *testing.T) {
+		later := ends.AddDate(0, 1, 0)
+		got := entitlementEndsAt(null.TimeFrom(ends), null.TimeFrom(later))
+		assert.Equal(t, null.TimeFrom(ends), got)
+	})
+
+	t.Run("ends_at is used when the subscription will not renew", func(t *testing.T) {
+		got := entitlementEndsAt(null.Time{}, null.TimeFrom(ends))
+		assert.Equal(t, null.TimeFrom(ends), got)
+	})
+
+	t.Run("a subscription with neither date ends the entitlement now", func(t *testing.T) {
+		before := time.Now().UTC()
+		got := entitlementEndsAt(null.Time{}, null.Time{})
+
+		// A paused subscription reports neither date. The entitlement has to
+		// land in the past so ActiveEntitlements stops returning it.
+		assert.True(t, got.Valid)
+		assert.False(t, got.Time.Before(before))
+		assert.False(t, got.Time.After(time.Now().UTC()))
+	})
+}

--- a/kite-service/internal/api/handler/billing/webhook.go
+++ b/kite-service/internal/api/handler/billing/webhook.go
@@ -4,14 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"time"
+	"strconv"
 
 	"github.com/NdoleStudio/lemonsqueezy-go"
 	"github.com/kitecloud/kite/kite-service/internal/api/handler"
 	"github.com/kitecloud/kite/kite-service/internal/api/wire"
-	"github.com/kitecloud/kite/kite-service/internal/model"
-	"github.com/kitecloud/kite/kite-service/internal/util"
-	"gopkg.in/guregu/null.v4"
 )
 
 // subscriptionEventNames are the events whose data object is a subscription,
@@ -73,90 +70,31 @@ func (h *BillingHandler) HandleBillingWebhook(c *handler.Context, body json.RawM
 
 	sub := req.Data.Attributes
 
-	subscription, err := h.subscriptionStore.UpsertLemonSqueezySubscription(c.Context(), model.Subscription{
-		ID:                         util.UniqueID(),
-		DisplayName:                sub.ProductName,
-		Source:                     model.SubscriptionSourceLemonSqueezy,
+	_, err := h.syncSubscription(c.Context(), subscriptionSync{
+		LemonSqueezySubscriptionID: req.Data.ID,
+		UserID:                     userID,
+		AppID:                      appID,
+		ProductName:                sub.ProductName,
 		Status:                     sub.Status,
 		StatusFormatted:            sub.StatusFormatted,
+		LemonSqueezyCustomerID:     strconv.Itoa(sub.CustomerID),
+		LemonSqueezyOrderID:        strconv.Itoa(sub.OrderID),
+		LemonSqueezyProductID:      strconv.Itoa(sub.ProductID),
+		LemonSqueezyVariantID:      strconv.Itoa(sub.VariantID),
 		RenewsAt:                   sub.RenewsAt,
 		TrialEndsAt:                sub.TrialEndsAt,
 		EndsAt:                     sub.EndsAt,
 		CreatedAt:                  sub.CreatedAt,
 		UpdatedAt:                  sub.UpdatedAt,
-		UserID:                     userID,
-		LemonsqueezySubscriptionID: null.StringFrom(req.Data.ID),
-		LemonsqueezyCustomerID:     null.StringFrom(fmt.Sprintf("%d", sub.CustomerID)),
-		LemonsqueezyOrderID:        null.StringFrom(fmt.Sprintf("%d", sub.OrderID)),
-		LemonsqueezyProductID:      null.StringFrom(fmt.Sprintf("%d", sub.ProductID)),
-		LemonsqueezyVariantID:      null.StringFrom(fmt.Sprintf("%d", sub.VariantID)),
 	})
 	if err != nil {
 		slog.Error(
-			"Failed to upsert subscription",
+			"Failed to sync subscription from webhook",
+			slog.String("event_name", eventName),
 			slog.String("ls_subscription_id", req.Data.ID),
 			slog.String("error", err.Error()),
 		)
-		return nil, fmt.Errorf("failed to upsert subscription: %w", err)
-	}
-
-	// We use the renews_at date as the default entitlement end date.
-	// If the subscription ends at a date that is before the renews_at date, we use the subscription ends_at date.
-	entitlementEndsAt := sub.RenewsAt
-	if sub.EndsAt.Valid && (!entitlementEndsAt.Valid || sub.EndsAt.Time.Before(entitlementEndsAt.Time)) {
-		entitlementEndsAt = sub.EndsAt
-	}
-	if !entitlementEndsAt.Valid {
-		// Neither date is set, which means the subscription will not renew and
-		// has no remaining paid period - a paused one, for example. Ending the
-		// entitlement now keeps it out of ActiveEntitlements.
-		entitlementEndsAt = null.TimeFrom(time.Now().UTC())
-	}
-
-	plan := h.planManager.PlanByLemonSqueezyProductID(fmt.Sprintf("%d", sub.ProductID))
-	if plan == nil {
-		slog.Error(
-			"Failed to find plan ID for subscription",
-			slog.String("ls_subscription_id", req.Data.ID),
-			slog.String("ls_product_id", fmt.Sprintf("%d", sub.ProductID)),
-		)
-		return nil, fmt.Errorf("failed to find plan ID for subscription")
-	}
-
-	entitlement := model.Entitlement{
-		ID:             util.UniqueID(),
-		Type:           "subscription",
-		SubscriptionID: null.StringFrom(subscription.ID),
-		AppID:          appID,
-		PlanID:         plan.ID,
-		CreatedAt:      time.Now().UTC(),
-		UpdatedAt:      time.Now().UTC(),
-		EndsAt:         entitlementEndsAt,
-	}
-
-	if appID != "" {
-		// Create a new entitlement or update the existing one
-		_, err := h.entitlementStore.UpsertSubscriptionEntitlement(c.Context(), entitlement)
-		if err != nil {
-			slog.Error(
-				"Failed to upsert subscription entitlement",
-				slog.String("subscription_id", subscription.ID),
-				slog.String("ls_subscription_id", req.Data.ID),
-				slog.String("error", err.Error()),
-			)
-			return nil, fmt.Errorf("failed to upsert subscription entitlement: %w", err)
-		}
-	} else {
-		// We don't have the app ID, but there might be an entitlement anyway, so we update that
-		err := h.entitlementStore.UpdateSubscriptionEntitlement(c.Context(), entitlement)
-		if err != nil {
-			slog.Error(
-				"Failed to update subscription entitlement",
-				slog.String("subscription_id", subscription.ID),
-				slog.String("error", err.Error()),
-			)
-			return nil, fmt.Errorf("failed to update subscription entitlement: %w", err)
-		}
+		return nil, err
 	}
 
 	return &wire.BillingWebhookResponse{}, nil

--- a/kite-service/internal/api/routes.go
+++ b/kite-service/internal/api/routes.go
@@ -165,6 +165,7 @@ func (s *APIServer) RegisterRoutes(
 	appBillingGroup := appGroup.Group("/billing")
 	appBillingGroup.Get("/subscriptions", handler.Typed(billingHandler.HandleAppSubscriptionList))
 	appBillingGroup.Post("/checkout", handler.TypedWithBody(billingHandler.HandleAppCheckout))
+	appBillingGroup.Put("/subscriptions/{subscriptionID}/plan", handler.TypedWithBody(billingHandler.HandleSubscriptionPlanUpdate))
 	appBillingGroup.Get("/features", handler.Typed(billingHandler.HandleFeaturesGet))
 
 	// Log routes

--- a/kite-service/internal/api/wire/billing.go
+++ b/kite-service/internal/api/wire/billing.go
@@ -51,6 +51,12 @@ type BillingCheckoutResponse struct {
 	URL string `json:"url"`
 }
 
+type SubscriptionPlanUpdateRequest struct {
+	LemonSqueezyVariantID string `json:"lemonsqueezy_variant_id"`
+}
+
+type SubscriptionPlanUpdateResponse = Subscription
+
 type SubscriptionManageResponse struct {
 	UpdatePaymentMethodURL string `json:"update_payment_method_url"`
 	CustomerPortalURL      string `json:"customer_portal_url"`

--- a/kite-service/internal/core/plan/manager.go
+++ b/kite-service/internal/core/plan/manager.go
@@ -53,6 +53,15 @@ func (m *PlanManager) PlanByLemonSqueezyProductID(productID string) *model.Plan 
 	return nil
 }
 
+func (m *PlanManager) PlanByLemonSqueezyVariantID(variantID string) *model.Plan {
+	for _, plan := range m.plans {
+		if plan.LemonSqueezyVariantID == variantID {
+			return &plan
+		}
+	}
+	return nil
+}
+
 func (m *PlanManager) AppFeatures(ctx context.Context, appID string) model.Features {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()

--- a/kite-web/src/components/app/AppPricingList.tsx
+++ b/kite-web/src/components/app/AppPricingList.tsx
@@ -11,9 +11,13 @@ import {
 import { Badge } from "../ui/badge";
 import { useAppSubscriptions, useBillingPlans } from "@/lib/hooks/api";
 import { ReactNode, useMemo } from "react";
-import { useLemonSqueezyCheckout } from "@/lib/hooks/lemonsqueezy";
+import {
+  useLemonSqueezyCheckout,
+  useSubscriptionPlanSwitch,
+} from "@/lib/hooks/lemonsqueezy";
 import { formatNumber } from "@/lib/utils";
 import { isSubscriptionActive } from "@/lib/subscriptions";
+import ConfirmDialog from "../common/ConfirmDialog";
 
 export default function AppPricingList() {
   const subscriptions = useAppSubscriptions();
@@ -41,7 +45,16 @@ export default function AppPricingList() {
     );
   }, [activeSubscriptions, plans]);
 
+  // Switching plans updates the existing subscription instead of buying a
+  // second one. We can only do that for a subscription the current user owns.
+  const switchableSubscription = activeSubscriptions?.find(
+    (subscription) => subscription!.manageable
+  );
+  const blockedByOtherOwner =
+    !switchableSubscription && !!activeSubscriptions?.length;
+
   const checkout = useLemonSqueezyCheckout();
+  const switchPlan = useSubscriptionPlanSwitch(switchableSubscription?.id);
 
   return (
     <div className="grid lg:grid-cols-2 xl:grid-cols-3 gap-8 xl:mx-16">
@@ -72,14 +85,39 @@ export default function AppPricingList() {
           </CardHeader>
 
           <CardContent>
-            <Button
-              className="w-full"
-              disabled={pricing.current || pricing.price === 0}
-              variant={pricing.popular ? "default" : "outline"}
-              onClick={() => checkout(pricing.lemonsqueezy_variant_id)}
-            >
-              {pricing.current ? "Current Plan" : "Get Started"}
-            </Button>
+            {switchableSubscription && !pricing.current ? (
+              <ConfirmDialog
+                title={`Switch to ${pricing.title}?`}
+                description={
+                  "Your subscription changes to this plan straight away. " +
+                  "LemonSqueezy charges or credits you the prorated difference for the rest of the current billing period."
+                }
+                onConfirm={() => switchPlan(pricing.lemonsqueezy_variant_id)}
+              >
+                <Button
+                  className="w-full"
+                  disabled={pricing.price === 0}
+                  variant={pricing.popular ? "default" : "outline"}
+                >
+                  Switch Plan
+                </Button>
+              </ConfirmDialog>
+            ) : (
+              <Button
+                className="w-full"
+                disabled={
+                  pricing.current || pricing.price === 0 || blockedByOtherOwner
+                }
+                variant={pricing.popular ? "default" : "outline"}
+                onClick={() => checkout(pricing.lemonsqueezy_variant_id)}
+              >
+                {pricing.current
+                  ? "Current Plan"
+                  : blockedByOtherOwner
+                  ? "Managed by another user"
+                  : "Get Started"}
+              </Button>
+            )}
           </CardContent>
 
           <hr className="w-4/5 m-auto mb-4" />

--- a/kite-web/src/components/app/AppPricingList.tsx
+++ b/kite-web/src/components/app/AppPricingList.tsx
@@ -90,7 +90,7 @@ export default function AppPricingList() {
                 title={`Switch to ${pricing.title}?`}
                 description={
                   "Your subscription changes to this plan straight away. " +
-                  "LemonSqueezy charges or credits you the prorated difference for the rest of the current billing period."
+                  "Our payment provider charges or credits you the prorated difference for the rest of the current billing period."
                 }
                 onConfirm={() => switchPlan(pricing.lemonsqueezy_variant_id)}
               >

--- a/kite-web/src/lib/api/mutations.ts
+++ b/kite-web/src/lib/api/mutations.ts
@@ -53,6 +53,8 @@ import {
   PluginInstanceUpdateResponse,
   StateGuildLeaveResponse,
   SubscriptionManageResponse,
+  SubscriptionPlanUpdateRequest,
+  SubscriptionPlanUpdateResponse,
   VariableCreateRequest,
   VariableCreateResponse,
   VariableDeleteResponse,
@@ -726,6 +728,33 @@ export function useCheckoutCreateMutation(appId: string) {
           },
         }
       );
+    },
+  });
+}
+
+export function useAppSubscriptionPlanUpdateMutation(
+  appId: string,
+  subscriptionId: string
+) {
+  return useMutation({
+    mutationFn: (req: SubscriptionPlanUpdateRequest) =>
+      apiRequest<SubscriptionPlanUpdateResponse>(
+        `/v1/apps/${appId}/billing/subscriptions/${subscriptionId}/plan`,
+        {
+          method: "PUT",
+          body: JSON.stringify(req),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      ),
+    onSuccess: () => {
+      client.invalidateQueries({
+        queryKey: ["apps", appId, "subscriptions"],
+      });
+      client.invalidateQueries({
+        queryKey: ["apps", appId, "billing", "features"],
+      });
     },
   });
 }

--- a/kite-web/src/lib/hooks/lemonsqueezy.ts
+++ b/kite-web/src/lib/hooks/lemonsqueezy.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import {
   useAppSubscriptionManageMutation,
+  useAppSubscriptionPlanUpdateMutation,
   useCheckoutCreateMutation,
 } from "../api/mutations";
 import { useAppId } from "./params";
@@ -30,6 +31,41 @@ export function useLemonSqueezyCheckout() {
       );
     },
     [checkoutMutation]
+  );
+}
+
+// useSubscriptionPlanSwitch moves an existing subscription onto another plan.
+// The returned callback is a no-op without a subscription to switch, so callers
+// can hold the hook unconditionally.
+export function useSubscriptionPlanSwitch(subscriptionId: string | undefined) {
+  const appId = useAppId();
+  const planUpdateMutation = useAppSubscriptionPlanUpdateMutation(
+    appId,
+    subscriptionId ?? ""
+  );
+
+  return useCallback(
+    (variantId: string) => {
+      if (!subscriptionId) return;
+
+      planUpdateMutation.mutate(
+        {
+          lemonsqueezy_variant_id: variantId,
+        },
+        {
+          onSuccess(res) {
+            if (res.success) {
+              toast.success("Your plan has been updated.");
+            } else {
+              toast.error(
+                `Failed to switch plan: ${res.error.message} ${res.error.code}`
+              );
+            }
+          },
+        }
+      );
+    },
+    [planUpdateMutation, subscriptionId]
   );
 }
 

--- a/kite-web/src/lib/types/wire.gen.ts
+++ b/kite-web/src/lib/types/wire.gen.ts
@@ -155,6 +155,10 @@ export interface BillingCheckoutRequest {
 export interface BillingCheckoutResponse {
   url: string;
 }
+export interface SubscriptionPlanUpdateRequest {
+  lemonsqueezy_variant_id: string;
+}
+export type SubscriptionPlanUpdateResponse = Subscription;
 export interface SubscriptionManageResponse {
   update_payment_method_url: string;
   customer_portal_url: string;


### PR DESCRIPTION
**3 of 4 in a stack.** Targets `merlin/billing-nullable-renews-at` (#332) — review #331 and #332 first.

Every plan button went through checkout, so a subscriber changing plans bought a *second* subscription. They were billed twice and both entitlements merged through `featuresFromEntitlements`.

Adds `PUT /apps/{appID}/billing/subscriptions/{subscriptionID}/plan`, which moves the existing subscription to the new variant. Prorated and invoiced immediately, so the new plan's features apply from that moment rather than from the next renewal. The pricing list offers "Switch Plan" behind a confirmation whenever the user owns an active subscription for the app.

## Note for reviewers

The lookup goes through the app's subscriptions rather than by ID alone. Looking it up by ID would let someone with access to two apps point one subscription at both and mint a second entitlement — same class of issue as the tenant-scoping work.

Persisting the subscription moved into a shared helper so the plan change and the webhook cannot drift apart. The plan change writes the result straight away instead of waiting for the webhook, since we cannot rely on it having arrived by the time the client refetches.

## Behaviour decisions

Proration and immediate invoicing, both upgrades and downgrades — confirmed with @merlinfuchs before implementing.

## Testing

`go build`, `go vet`, `go test`, `tsc --noEmit` and `next lint` all clean. Unit tests cover the entitlement date logic.